### PR TITLE
Feature/api config projects

### DIFF
--- a/youwol/configuration/configuration_handler.py
+++ b/youwol/configuration/configuration_handler.py
@@ -5,10 +5,10 @@ from pathlib import Path
 from typing import Optional, List, Union, Dict
 
 from youwol.configuration.defaults import default_http_port, default_path_data_dir, \
-    default_path_cache_dir, default_path_projects_dir, default_port_range_start, default_port_range_end, \
+    default_path_cache_dir, default_port_range_start, default_port_range_end, \
     default_platform_host, default_jwt_source
 from youwol.configuration.models_config import Profiles, ConfigurationData, PortRange, ModuleLoading, \
-    CascadeBaseProfile, CascadeAppend, CascadeReplace, CdnOverride, Redirection, JwtSource, PipelinesSourceInfo
+    CascadeBaseProfile, CascadeAppend, CascadeReplace, CdnOverride, Redirection, JwtSource, Projects
 
 from youwol.environment.models import Events, IConfigurationCustomizer
 from youwol.environment.paths import app_dirs
@@ -34,7 +34,7 @@ def replace_with(parent: ConfigurationData, replacement: ConfigurationData) -> C
         redirectBasePath=replacement.redirectBasePath if replacement.redirectBasePath else parent.redirectBasePath,
         openIdHost=replacement.openIdHost if replacement.openIdHost else parent.openIdHost,
         user=replacement.user if replacement.user else parent.user,
-        projectsDirs=replacement.projectsDirs if replacement.projectsDirs else parent.projectsDirs,
+        projects=replacement.projects if replacement.projects else parent.projects,
         configDir=replacement.configDir if replacement.configDir else parent.configDir,
         dataDir=replacement.dataDir if replacement.dataDir else parent.dataDir,
         cacheDir=replacement.cacheDir if replacement.cacheDir else parent.cacheDir,
@@ -44,10 +44,7 @@ def replace_with(parent: ConfigurationData, replacement: ConfigurationData) -> C
         defaultModulePath=replacement.defaultModulePath if replacement.defaultModulePath else parent.defaultModulePath,
         events=replacement.events if replacement.events else parent.events,
         customCommands=replacement.customCommands if replacement.customCommands else parent.customCommands,
-        customize=replacement.customize if replacement.customize else parent.customize,
-        pipelinesSourceInfo=replacement.pipelinesSourceInfo
-        if replacement.pipelinesSourceInfo
-        else parent.pipelinesSourceInfo
+        customize=replacement.customize if replacement.customize else parent.customize
     )
 
 
@@ -129,14 +126,8 @@ class ConfigurationHandler:
         path = self.effective_config_data.cacheDir if self.effective_config_data.cacheDir else default_path_cache_dir
         return ensure_dir_exists(path, root_candidates=app_dirs.user_cache_dir)
 
-    def get_projects_dirs(self) -> List[Path]:
-        path = self.effective_config_data.projectsDirs \
-            if self.effective_config_data.projectsDirs else default_path_projects_dir
-        if isinstance(path, str) or isinstance(path, Path):
-            return [ensure_dir_exists(path, root_candidates=Path().home())]
-        else:
-            return [ensure_dir_exists(path_str, root_candidates=Path().home())
-                    for path_str in self.effective_config_data.projectsDirs]
+    def get_projects(self) -> Projects:
+        return self.effective_config_data.projects or Projects()
 
     def get_dispatches(self) -> List[AbstractDispatch]:
         if not self.effective_config_data.dispatches:
@@ -249,9 +240,6 @@ class ConfigurationHandler:
 
         return [ensure_dir_exists(path=path, root_candidates=path_user_lib)
                 for path in paths]
-
-    def get_pipelines_source_info(self) -> PipelinesSourceInfo:
-        return self.effective_config_data.pipelinesSourceInfo
 
     def get_ports_book(self) -> Dict[str, int]:
         return self.effective_config_data.portsBook or {}

--- a/youwol/configuration/models_config.py
+++ b/youwol/configuration/models_config.py
@@ -54,8 +54,11 @@ class UploadTargets(BaseModel):
 
 class Projects(BaseModel):
     finder: Union[
+        ConfigPath,
+        List[ConfigPath],
         Callable[[YouwolEnvironment, Context], List[ConfigPath]],
-        Callable[[YouwolEnvironment, Context], Awaitable[List[ConfigPath]]]
+        Callable[[YouwolEnvironment, Context], Awaitable[List[ConfigPath]]],
+        ModuleLoading
     ] = None
     templates: List[ProjectTemplate] = []
     uploadTargets: List[UploadTargets] = []

--- a/youwol/configuration/models_config.py
+++ b/youwol/configuration/models_config.py
@@ -1,13 +1,15 @@
 from enum import Enum
 from pathlib import Path
-from typing import List, Union, Optional, Dict
+from typing import List, Union, Optional, Dict, Callable, Awaitable
 
 from pydantic import BaseModel
 
+from youwol.environment.forward_declaration import YouwolEnvironment
 from youwol.environment.models import Events
 from youwol.environment.models_project import ProjectTemplate
 from youwol.middlewares.models_dispatch import AbstractDispatch, RedirectDispatch
 from youwol.routers.custom_commands.models import Command
+from youwol_utils import Context
 from youwol_utils.servers.fast_api import FastApiRouter
 
 
@@ -50,9 +52,13 @@ class UploadTargets(BaseModel):
     targets: List[UploadTarget]
 
 
-class PipelinesSourceInfo(BaseModel):
+class Projects(BaseModel):
+    finder: Union[
+        Callable[[YouwolEnvironment, Context], List[ConfigPath]],
+        Callable[[YouwolEnvironment, Context], Awaitable[List[ConfigPath]]]
+    ] = None
+    templates: List[ProjectTemplate] = []
     uploadTargets: List[UploadTargets] = []
-    projectTemplates: List[ProjectTemplate] = []
 
 
 class ConfigurationData(BaseModel):
@@ -64,7 +70,7 @@ class ConfigurationData(BaseModel):
     user: Optional[str]
     portsBook: Optional[Dict[str, int]]
     routers: Optional[List[FastApiRouter]]
-    projectsDirs: Optional[Union[ConfigPath, List[ConfigPath]]]
+    projects: Optional[Projects]
     configDir: Optional[ConfigPath]
     dataDir: Optional[ConfigPath]
     cacheDir: Optional[ConfigPath]
@@ -76,7 +82,6 @@ class ConfigurationData(BaseModel):
     events: Optional[Union[Events, str, ModuleLoading]]
     customCommands: List[Union[str, Command, ModuleLoading]] = []
     customize: Optional[Union[str, ModuleLoading]]
-    pipelinesSourceInfo: PipelinesSourceInfo = PipelinesSourceInfo()
 
 
 class CascadeBaseProfile(Enum):

--- a/youwol/configuration/models_config.py
+++ b/youwol/configuration/models_config.py
@@ -1,16 +1,19 @@
 from enum import Enum
 from pathlib import Path
-from typing import List, Union, Optional, Dict, Callable, Awaitable
+from typing import List, Union, Optional, Dict, Callable, Awaitable, Any
 
 from pydantic import BaseModel
 
 from youwol.environment.forward_declaration import YouwolEnvironment
-from youwol.environment.models import Events
 from youwol.environment.models_project import ProjectTemplate
 from youwol.middlewares.models_dispatch import AbstractDispatch, RedirectDispatch
 from youwol.routers.custom_commands.models import Command
 from youwol_utils import Context
 from youwol_utils.servers.fast_api import FastApiRouter
+
+
+class Events(BaseModel):
+    onLoad: Callable[[YouwolEnvironment, Context], Optional[Union[Any, Awaitable[Any]]]] = None
 
 
 class PortRange(BaseModel):

--- a/youwol/environment/config_from_module.py
+++ b/youwol/environment/config_from_module.py
@@ -90,11 +90,11 @@ class Configuration(ConfigurationData):
                           cascading: Union[CascadeAppend, CascadeReplace, CascadeBaseProfile]
                           = CascadeBaseProfile.REPLACE) -> Configuration:
         if self._cascading is not None:
-            raise Exception("Calling Configuration#extending_profile(…) on anything but base profile is forbidden")
+            raise RuntimeError("Calling Configuration#extending_profile(…) on anything but base profile is forbidden")
         if name == 'default':
-            raise Exception("Profile name 'default' is reserved")
+            raise RuntimeError("Profile name 'default' is reserved")
         if name in self._extending_profiles:
-            raise Exception(f"There is already a profile named '{name}'")
+            raise RuntimeError(f"There is already a profile named '{name}'")
         conf._cascading = cascading
         self._extending_profiles[name] = conf
         return self
@@ -108,7 +108,7 @@ class Configuration(ConfigurationData):
 
     def selected(self, name: str) -> Configuration:
         if self._cascading is not None:
-            raise Exception("Calling Configuration#selected(…) on anything but base profile is forbidden")
+            raise RuntimeError("Calling Configuration#selected(…) on anything but base profile is forbidden")
 
         self._selected = name
         return self

--- a/youwol/environment/config_from_module.py
+++ b/youwol/environment/config_from_module.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, Awaitable, Dict, Union
 
-from youwol.configuration.configuration_handler import ConfigurationHandler
+from youwol.environment.configuration_handler import ConfigurationHandler
 from youwol.configuration.configuration_validation import CheckValidConfigurationFunction, ConfigurationLoadingStatus, \
     ConfigurationLoadingException
 from youwol.configuration.models_config import Profiles, ConfigurationData, \

--- a/youwol/environment/config_from_static_file.py
+++ b/youwol/environment/config_from_static_file.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional, Dict
 
-from youwol.configuration.configuration_handler import ConfigurationHandler
+from youwol.environment.configuration_handler import ConfigurationHandler
 from youwol.configuration.models_config import Profiles, ConfigurationData, Cascade, CascadeBaseProfile, \
     ExtendingProfile
 from youwol.environment.paths import app_dirs

--- a/youwol/environment/configuration_handler.py
+++ b/youwol/environment/configuration_handler.py
@@ -12,7 +12,7 @@ from youwol.configuration.models_config import Profiles, ConfigurationData, Port
     CascadeBaseProfile, CascadeAppend, CascadeReplace, CdnOverride, Redirection, JwtSource
 from youwol.environment.models import Events, IConfigurationCustomizer, Projects
 from youwol.environment.paths import app_dirs
-from youwol.environment.projects_loader import default_projects_finder
+from youwol.environment.utils import default_projects_finder
 from youwol.main_args import get_main_arguments
 from youwol.middlewares.models_dispatch import CdnOverrideDispatch, RedirectDispatch, AbstractDispatch
 from youwol.routers.custom_commands.models import Command

--- a/youwol/environment/configuration_handler.py
+++ b/youwol/environment/configuration_handler.py
@@ -9,8 +9,8 @@ from youwol.configuration.defaults import default_http_port, default_path_data_d
     default_path_cache_dir, default_port_range_start, default_port_range_end, \
     default_platform_host, default_jwt_source
 from youwol.configuration.models_config import Profiles, ConfigurationData, PortRange, ModuleLoading, \
-    CascadeBaseProfile, CascadeAppend, CascadeReplace, CdnOverride, Redirection, JwtSource
-from youwol.environment.models import Events, IConfigurationCustomizer, Projects
+    CascadeBaseProfile, CascadeAppend, CascadeReplace, CdnOverride, Redirection, JwtSource, Events
+from youwol.environment.models import IConfigurationCustomizer, Projects
 from youwol.environment.paths import app_dirs
 from youwol.environment.utils import default_projects_finder
 from youwol.main_args import get_main_arguments

--- a/youwol/environment/models.py
+++ b/youwol/environment/models.py
@@ -1,11 +1,12 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pydantic import BaseModel
 from typing import List, Dict, Callable, Optional, Union, Any, Awaitable
 
-from pydantic import BaseModel
-
+from youwol.configuration.models_config import ConfigPath, UploadTargets
 from youwol.environment.forward_declaration import YouwolEnvironment
-from youwol.environment.models_project import Pipeline
+from youwol.environment.models_project import Pipeline, ProjectTemplate
+from youwol.environment.projects_loader import default_projects_finder
 from youwol_utils.clients.oidc.oidc_config import PrivateClient, PublicClient
 from youwol_utils.context import Context
 
@@ -55,3 +56,11 @@ class IConfigurationCustomizer(ABC):
     async def customize(self, _youwol_configuration: YouwolEnvironment) -> YouwolEnvironment:
         return NotImplemented
 
+
+class Projects(BaseModel):
+    finder: Callable[
+        [YouwolEnvironment, Context],
+        Awaitable[List[ConfigPath]]
+    ] = lambda env, _ctx: default_projects_finder(env=env)
+    templates: List[ProjectTemplate] = []
+    uploadTargets: List[UploadTargets] = []

--- a/youwol/environment/models.py
+++ b/youwol/environment/models.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pydantic import BaseModel
-from typing import List, Dict, Callable, Optional, Union, Any, Awaitable
+from typing import List, Dict, Callable, Optional, Union, Awaitable
 
 from youwol.configuration.models_config import ConfigPath, UploadTargets
 from youwol.environment.forward_declaration import YouwolEnvironment
@@ -45,9 +45,6 @@ class IPipelineFactory(ABC):
     async def get(self, env: YouwolEnvironment, context: Context) -> Pipeline:
         return NotImplemented
 
-
-class Events(BaseModel):
-    onLoad: Callable[[YouwolEnvironment, Context], Optional[Union[Any, Awaitable[Any]]]] = None
 
 
 class IConfigurationCustomizer(ABC):

--- a/youwol/environment/models.py
+++ b/youwol/environment/models.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Callable, Optional, Union, Any, Awaitable
 from youwol.configuration.models_config import ConfigPath, UploadTargets
 from youwol.environment.forward_declaration import YouwolEnvironment
 from youwol.environment.models_project import Pipeline, ProjectTemplate
-from youwol.environment.projects_loader import default_projects_finder
+from youwol.environment.utils import default_projects_finder
 from youwol_utils.clients.oidc.oidc_config import PrivateClient, PublicClient
 from youwol_utils.context import Context
 

--- a/youwol/environment/paths.py
+++ b/youwol/environment/paths.py
@@ -16,7 +16,6 @@ class PathsBook(BaseModel):
     config: Path
     system: Path
     databases: Path
-    projects: List[Path]
     additionalPythonScrPaths: List[Path]
     usersInfo: Path
     remotesInfo: Path
@@ -129,8 +128,6 @@ class PathsBook(BaseModel):
  * config file: {self.config}
  * databases directory: {self.databases}
  * system directory: {self.system}
- * projects directories:
-{chr(10).join([f"  * {path}" for path in self.projects])} 
  * additional Python source directories:
 {chr(10).join([f"  * {path}" for path in self.additionalPythonScrPaths])}"""
 

--- a/youwol/environment/utils.py
+++ b/youwol/environment/utils.py
@@ -1,0 +1,41 @@
+import itertools
+from pathlib import Path
+from typing import Union, List
+
+from youwol.configuration.defaults import default_path_projects_dir
+from youwol.environment.forward_declaration import YouwolEnvironment
+from youwol_utils.utils_paths import FileListing, matching_files
+
+
+def default_projects_finder(env: YouwolEnvironment, root_folders: Union[None, str, Path, List[str], List[Path]] = None):
+    if not root_folders:
+        (Path.home() / default_path_projects_dir).mkdir(exist_ok=True)
+
+    root_folders = [Path.home() / default_path_projects_dir] if not root_folders else root_folders
+    root_folders = root_folders if isinstance(root_folders, List) else [root_folders]
+    results = [auto_detect_projects(env=env, root_folder=root_folder, ignore=["**/dist", '**/py-youwol'])
+               for root_folder in root_folders]
+
+    return itertools.chain.from_iterable(results)
+
+
+def auto_detect_projects(env: YouwolEnvironment, root_folder: Union[Path, str], ignore: List[str] = None):
+    database_ignore = None
+    system_ignore = None
+    root_folder = Path(root_folder)
+    try:
+        database_ignore = env.pathsBook.databases.relative_to(root_folder)
+    except ValueError:
+        pass
+    try:
+        system_ignore = env.pathsBook.system.relative_to(root_folder)
+    except ValueError:
+        pass
+
+    ignore = (ignore or []) + [str(path) for path in [database_ignore, system_ignore] if path]
+    file_listing = FileListing(
+        include=["**/.yw_pipeline/yw_pipeline.py"],
+        ignore=["**/node_modules", "**/.template", "**/.git"] + ignore
+    )
+    yw_pipelines = matching_files(root_folder, file_listing)
+    return [p.parent.parent for p in yw_pipelines]

--- a/youwol/environment/youwol_environment.py
+++ b/youwol/environment/youwol_environment.py
@@ -20,9 +20,9 @@ from youwol.configuration.configuration_validation import (
     CheckSecretHealthy
 )
 from youwol.configuration.defaults import default_platform_host
-from youwol.configuration.models_config import JwtSource
+from youwol.configuration.models_config import JwtSource, Events
 from youwol.environment.clients import LocalClients
-from youwol.environment.models import RemoteGateway, UserInfo, ApiConfiguration, Events, Projects
+from youwol.environment.models import RemoteGateway, UserInfo, ApiConfiguration, Projects
 from youwol.environment.models_project import ErrorResponse
 from youwol.environment.paths import PathsBook, ensure_config_file_exists_or_create_it
 from youwol.main_args import get_main_arguments, MainArguments

--- a/youwol/environment/youwol_environment.py
+++ b/youwol/environment/youwol_environment.py
@@ -11,9 +11,9 @@ from pydantic import BaseModel
 from typing import Dict, Any, Union, Optional, Awaitable, List
 
 import youwol
-from youwol.configuration.config_from_module import configuration_from_python
-from youwol.configuration.config_from_static_file import configuration_from_json
-from youwol.configuration.configuration_handler import ConfigurationHandler
+from youwol.environment.config_from_module import configuration_from_python
+from youwol.environment.config_from_static_file import configuration_from_json
+from youwol.environment.configuration_handler import ConfigurationHandler
 from youwol.configuration.configuration_validation import (
     ConfigurationLoadingStatus, ConfigurationLoadingException,
     CheckSystemFolderWritable, CheckDatabasesFolderHealthy, CheckSecretPathExist,

--- a/youwol/environment/youwol_environment.py
+++ b/youwol/environment/youwol_environment.py
@@ -1,15 +1,14 @@
 import json
 import os
 import shutil
-from datetime import datetime
-from getpass import getpass
-from pathlib import Path
-from typing import Dict, Any, Union, Optional, Awaitable, List
-
 from colorama import Fore, Style
 from cowpy import cow
+from datetime import datetime
 from fastapi import HTTPException
+from getpass import getpass
+from pathlib import Path
 from pydantic import BaseModel
+from typing import Dict, Any, Union, Optional, Awaitable, List
 
 import youwol
 from youwol.configuration.config_from_module import configuration_from_python
@@ -21,9 +20,9 @@ from youwol.configuration.configuration_validation import (
     CheckSecretHealthy
 )
 from youwol.configuration.defaults import default_platform_host
-from youwol.configuration.models_config import JwtSource, Projects
+from youwol.configuration.models_config import JwtSource
 from youwol.environment.clients import LocalClients
-from youwol.environment.models import RemoteGateway, UserInfo, ApiConfiguration, Events
+from youwol.environment.models import RemoteGateway, UserInfo, ApiConfiguration, Events, Projects
 from youwol.environment.models_project import ErrorResponse
 from youwol.environment.paths import PathsBook, ensure_config_file_exists_or_create_it
 from youwol.main_args import get_main_arguments, MainArguments

--- a/youwol/pipelines/pipeline_fastapi_youwol_backend/pipeline.py
+++ b/youwol/pipelines/pipeline_fastapi_youwol_backend/pipeline.py
@@ -16,6 +16,8 @@ from youwol_utils.context import Context
 
 
 def get_dependencies(project: Project) -> Set[str]:
+    if not (project.path / 'requirements.txt').exists():
+        return set()
     with (project.path / 'requirements.txt').open() as requirements_txt:
         install_requires = [
             str(requirement)
@@ -223,12 +225,12 @@ async def pipeline(
 
         env: YouwolEnvironment = await ctx.get('env', YouwolEnvironment)
 
-        docker = next(d for d in env.pipelinesSourceInfo.uploadTargets if isinstance(d, DockerImagesPush))
+        docker = next(d for d in env.projects.uploadTargets if isinstance(d, DockerImagesPush))
         docker_repo = docker.get_repo(config.dockerConfig.repoName)
 
         dry_run_config = InstallHelmStepConfig(**config.helmConfig.dict())
         dry_run_config.overridingHelmValues = add_dry_values
-        k8s = next(deployment for deployment in env.pipelinesSourceInfo.uploadTargets
+        k8s = next(deployment for deployment in env.projects.uploadTargets
                    if isinstance(deployment, HelmChartsInstall))
 
         install_helm_steps = [InstallHelmStep(id=f'install-helm_{k8sTarget.name}',

--- a/youwol/pipelines/pipeline_typescript_weback_npm/common/utils.py
+++ b/youwol/pipelines/pipeline_typescript_weback_npm/common/utils.py
@@ -171,7 +171,7 @@ def generate_webpack_config(source: Path, working_path: Path, input_template: Te
 async def create_sub_pipelines_publish_cdn(start_step: str, context: Context):
 
     env: YouwolEnvironment = await context.get('env', YouwolEnvironment)
-    cdn_targets = next((uploadTarget for uploadTarget in env.pipelinesSourceInfo.uploadTargets
+    cdn_targets = next((uploadTarget for uploadTarget in env.projects.uploadTargets
                         if isinstance(uploadTarget, PackagesPublishYwCdn)), PackagesPublishYwCdn(targets=[]))
 
     publish_cdn_steps: List[PipelineStep] = [PublishCdnRemoteStep(id=f'cdn_{cdn_target.name}',
@@ -185,7 +185,7 @@ async def create_sub_pipelines_publish_cdn(start_step: str, context: Context):
 async def create_sub_pipelines_publish_npm(start_step: str, context: Context):
 
     env: YouwolEnvironment = await context.get('env', YouwolEnvironment)
-    npm_targets = next((uploadTarget for uploadTarget in env.pipelinesSourceInfo.uploadTargets
+    npm_targets = next((uploadTarget for uploadTarget in env.projects.uploadTargets
                         if isinstance(uploadTarget, PackagesPublishNpm)), PackagesPublishNpm(targets=[]))
     publish_npm_steps: List[PipelineStep] = [PublishNpmStep(id=f'npm_{npm_target.name}', npm_target=npm_target)
                                              for npm_target in npm_targets.targets]

--- a/youwol/pipelines/publish_cdn.py
+++ b/youwol/pipelines/publish_cdn.py
@@ -97,7 +97,7 @@ class PublishCdnLocalStep(PipelineStep):
             try:
                 local_lib_info = await local_cdn.get_library_info(
                     library_id=encode_id(project.publishName),
-                    headers=ctx.headers()
+                    headers={YouwolHeaders.muted_http_errors: "404"}
                 )
             except HTTPException as e:
                 await ctx.info(text="The package has not been published yet in the local cdn")

--- a/youwol/routers/projects/router.py
+++ b/youwol/routers/projects/router.py
@@ -386,7 +386,7 @@ async def new_project_from_template(
             with_labels=[f"{Label.PROJECT_CREATING}"],
             with_reporters=[LogsStreamer()]
     ) as ctx:
-        template = next((template for template in config.pipelinesSourceInfo.projectTemplates
+        template = next((template for template in config.projects.templates
                          if template.type == body.type), None)
         if not template:
             raise RuntimeError(f"Can not find a template of type {body.type}")
@@ -440,4 +440,3 @@ async def do_cmd_get_pipeline_step(
             raise HTTPException(status_code=404, detail=f"The step has no command '{command_id}'")
 
         return await command.do_get(project, flow_id, ctx)
-


### PR DESCRIPTION
In a nutshell:
*   gather projectDirs, projectTemplates, uploadTargets in a same 'projects' object of Configuration
*   replace 'projectDirs' by a function 'finder' to let the consumer pick the way he wants to 'find' its projects
*  by default finder is all the pipelines under the parent of the config file