### PR TITLE
TG-108 : more than 100 items in a folder

### DIFF
--- a/youwol_tree_db_backend/configurations.py
+++ b/youwol_tree_db_backend/configurations.py
@@ -14,6 +14,9 @@ class Constants:
     default_owner = "/youwol-users"
     public_owner = '/youwol-users'
     text_content_type = "text/plain"
+    # This is the limit of children that can be fetched for a folder/drive.
+    # It has to disappear, see issue #158 files explorer: no max children count
+    max_children_count = 1000
 
 
 @dataclass(frozen=True)

--- a/youwol_tree_db_backend/root_paths.py
+++ b/youwol_tree_db_backend/root_paths.py
@@ -740,12 +740,15 @@ async def _children(
         folder_id: str,
         configuration: Configuration,
         context: Context):
+
+    # max_count: see comment in class 'Constants'
+    max_count = Constants.max_children_count
     async with context.start(action="_children") as ctx:  # type: Context
 
         folders_db, items_db = configuration.doc_dbs.folders_db, configuration.doc_dbs.items_db
         folders, items = await asyncio.gather(
-            db_query(docdb=folders_db, key="parent_folder_id", value=folder_id, max_count=100, context=ctx),
-            db_query(docdb=items_db, key="folder_id", value=folder_id, max_count=100, context=ctx)
+            db_query(docdb=folders_db, key="parent_folder_id", value=folder_id, max_count=max_count, context=ctx),
+            db_query(docdb=items_db, key="folder_id", value=folder_id, max_count=max_count, context=ctx)
         )
 
         return ChildrenResponse(folders=[doc_to_folder(f) for f in folders],


### PR DESCRIPTION
The hard-coded limit to fetch folder's children has been increased to 1000. Should be enough for now for the rare cases for which we have more than 100 children.

A better implementation is required anyway, see issue [#158](https://tooling.dev.youwol.com/taiga/project/pyyouwol/t/158)