### PR TITLE
TG-423 : py-youwol & multithreading & indexed data files

### DIFF
--- a/youwol/environment/youwol_environment.py
+++ b/youwol/environment/youwol_environment.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import json
 import os
+import shutil
 from pathlib import Path
 from typing import Dict, Any, Optional, Awaitable, List
 
@@ -44,6 +45,9 @@ class YouwolEnvironment(BaseModel):
 
     cache_user: Dict[str, Any] = {}
     cache_py_youwol: Dict[str, Any] = {}
+
+    def reset_databases(self):
+        shutil.rmtree(self.pathsBook.databases, ignore_errors=True)
 
     def reset_cache(self):
         self.cache_user = {}


### PR DESCRIPTION
This is a first step before making docdb documents in memory (see branch https://github.com/youwol/py-youwol/compare/main...feature/in-memory-db). The purpose is to keep backward compatibility with the cdn-client, http-clients & local-youwol-client tests.

second step is to use this new function in test configs

third step is to update the implementation of this function along with the branch feature/in-memory-docdb