### PR TITLE
TG-1727 Py-youwol predefined configs can use 'int' environment

### DIFF
--- a/.github/workflows/pull_request_checks.yml
+++ b/.github/workflows/pull_request_checks.yml
@@ -38,6 +38,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
 
 jobs:
   integration_local-youwol-client:
@@ -121,11 +122,11 @@ jobs:
         id: prepare
         uses: youwol/nestor/py-youwol/prepare@v3
 
-      - name: Checkout main branch
-        id: checkout_main_branch
+      - name: Checkout target branch
+        id: checkout_target_branch
         uses: actions/checkout@v3
         with:
-          ref: main
+          ref: ${{ github.base_ref }}
           path: .py-youwol_main
 
       - name: Static Analysis

--- a/src/youwol/app/environment/models/defaults.py
+++ b/src/youwol/app/environment/models/defaults.py
@@ -1,4 +1,6 @@
 # standard library
+import os
+
 from pathlib import Path
 
 # Youwol utilities
@@ -7,7 +9,12 @@ from youwol.utils.clients.oidc.oidc_config import PublicClient
 # Changing values defined in this file usually required updates in the documentation of models_config.
 
 default_http_port: int = 2000
-default_platform_host: str = "platform.youwol.com"
+default_platform_host: str = (
+    os.getenv("PY_YOUWOL_REMOTE")
+    if os.getenv("PY_YOUWOL_REMOTE")
+    else "platform.youwol.com"
+)
+
 default_openid_client_id: str = "tbd_test_openid_connect_js"
 default_path_data_dir: Path = Path("./databases")
 default_path_cache_dir: Path = Path("./system")

--- a/src/youwol/app/environment/models/models_config.py
+++ b/src/youwol/app/environment/models/models_config.py
@@ -431,10 +431,10 @@ class System(BaseModel):
     httpPort: Optional[int] = default_http_port
     tokensStorage: Optional[TokensStorageConf] = TokensStorageSystemKeyring()
     cloudEnvironments: CloudEnvironments = CloudEnvironments(
-        defaultConnection=Connection(envId="public-youwol", authId="browser"),
+        defaultConnection=Connection(envId="remote", authId="browser"),
         environments=[
             CloudEnvironment(
-                envId="public-youwol",
+                envId="remote",
                 host=default_platform_host,
                 authProvider=AuthorizationProvider(**default_auth_provider()),
                 authentications=[BrowserAuth(authId="browser")],

--- a/src/youwol/app/environment/models/predefined_configs/py_youwol_tour/new_ts_app.py
+++ b/src/youwol/app/environment/models/predefined_configs/py_youwol_tour/new_ts_app.py
@@ -1,5 +1,6 @@
 # Youwol application
 from youwol.app.environment import (
+    BrowserAuth,
     Configuration,
     LocalEnvironment,
     Projects,
@@ -24,8 +25,10 @@ pipeline_ts.set_environment(
     environment=pipeline_ts.Environment(
         cdnTargets=[
             CdnTarget(
-                name="prod",
-                cloudTarget=get_standard_youwol_env(env_id="prod"),
+                name="remote",
+                cloudTarget=get_standard_youwol_env(
+                    env_id="remote", authentications=[BrowserAuth(authId="browser")]
+                ),
                 authId="browser",
             ),
         ]

--- a/src/youwol/app/environment/models/predefined_configs/py_youwol_tour/new_ts_lib.py
+++ b/src/youwol/app/environment/models/predefined_configs/py_youwol_tour/new_ts_lib.py
@@ -1,5 +1,6 @@
 # Youwol application
 from youwol.app.environment import (
+    BrowserAuth,
     Configuration,
     LocalEnvironment,
     Projects,
@@ -26,8 +27,10 @@ pipeline_ts.set_environment(
     environment=pipeline_ts.Environment(
         cdnTargets=[
             CdnTarget(
-                name="prod",
-                cloudTarget=get_standard_youwol_env(env_id="prod"),
+                name="remote",
+                cloudTarget=get_standard_youwol_env(
+                    env_id="remote", authentications=[BrowserAuth(authId="browser")]
+                ),
                 authId="browser",
             ),
         ],

--- a/src/youwol/app/environment/online_environments.py
+++ b/src/youwol/app/environment/online_environments.py
@@ -32,6 +32,6 @@ def get_standard_youwol_env(
     return CloudEnvironment(
         envId=env_id,
         host=host,
-        authProvider=get_standard_auth_provider("platform.youwol.com", **kwargs),
+        authProvider=get_standard_auth_provider(host=host, **kwargs),
         authentications=authentications,
     )


### PR DESCRIPTION
- 🐛 [environment] `get_standard_youwol_env` => fix hard coded
- ✨ [environment] default host => rely on `os.getenv("PY_YOUWOL_REMOTE")`  if any
- 🎨 [environment] System => improve name of the default env.
- ♻️ [environment/predefined configs] => CloudTarget.authentications explicit.
- 👷 Checks for PR into releases branches

TG-1727 #closed