### PR TITLE
bug/docker image publish only gitlab

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            backends
             registry.gitlab.com/youwol/platform/backends
           tags: |
             type=pep440,pattern={{version}}


### PR DESCRIPTION
- 👷 `Docker Metadata`: tag only for Gitlab
