### PR TITLE
TG-1874 refactor http-clients & improve authentication

### DIFF
--- a/src/youwol/app/environment/__init__.py
+++ b/src/youwol/app/environment/__init__.py
@@ -1,6 +1,7 @@
 # relative
 from .clients import *
 from .config_from_module import *
+from .local_auth import *
 from .models import *
 from .online_environments import *
 from .paths import *

--- a/src/youwol/app/environment/clients.py
+++ b/src/youwol/app/environment/clients.py
@@ -1,5 +1,8 @@
+# third parties
+import aiohttp
+
 # Youwol utilities
-from youwol.utils import CdnClient
+from youwol.utils import AioHttpExecutor, CdnClient
 from youwol.utils.clients.accounts.accounts import AccountsClient
 from youwol.utils.clients.assets.assets import AssetsClient
 from youwol.utils.clients.assets_gateway.assets_gateway import AssetsGatewayClient
@@ -13,6 +16,10 @@ from youwol.utils.clients.treedb.treedb import TreeDbClient
 from .youwol_environment import YouwolEnvironment
 
 
+def client_session():
+    return aiohttp.ClientSession(auto_decompress=False)
+
+
 class RemoteClients:
     @staticmethod
     async def get_assets_gateway_client(remote_host: str) -> AssetsGatewayClient:
@@ -20,6 +27,8 @@ class RemoteClients:
 
 
 class LocalClients:
+    request_executor = AioHttpExecutor(client_session=client_session)
+
     @staticmethod
     def base_path(env: YouwolEnvironment):
         return f"http://localhost:{env.httpPort}/api"
@@ -27,66 +36,105 @@ class LocalClients:
     @staticmethod
     def get_assets_gateway_client(env: YouwolEnvironment) -> AssetsGatewayClient:
         base_path = LocalClients.base_path(env)
-        return AssetsGatewayClient(url_base=f"{base_path}/assets-gateway")
+        return AssetsGatewayClient(
+            url_base=f"{base_path}/assets-gateway",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_assets_client(env: YouwolEnvironment) -> AssetsClient:
         base_path = LocalClients.base_path(env)
-        return AssetsClient(url_base=f"{base_path}/assets-backend")
+        return AssetsClient(
+            url_base=f"{base_path}/assets-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_gtw_assets_client(env: YouwolEnvironment) -> AssetsClient:
         base_path = LocalClients.base_path(env)
-        return AssetsClient(url_base=f"{base_path}/assets-gateway/assets-backend")
+        return AssetsClient(
+            url_base=f"{base_path}/assets-gateway/assets-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_files_client(env: YouwolEnvironment) -> FilesClient:
         base_path = LocalClients.base_path(env)
-        return FilesClient(url_base=f"{base_path}/files-backend")
+        return FilesClient(
+            url_base=f"{base_path}/files-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_gtw_files_client(env: YouwolEnvironment) -> FilesClient:
         base_path = LocalClients.base_path(env)
-        return FilesClient(url_base=f"{base_path}/assets-gateway/files-backend")
+        return FilesClient(
+            url_base=f"{base_path}/assets-gateway/files-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_treedb_client(env: YouwolEnvironment) -> TreeDbClient:
         base_path = LocalClients.base_path(env)
-        return TreeDbClient(url_base=f"{base_path}/treedb-backend")
+        return TreeDbClient(
+            url_base=f"{base_path}/treedb-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_gtw_treedb_client(env: YouwolEnvironment) -> TreeDbClient:
         base_path = LocalClients.base_path(env)
-        return TreeDbClient(url_base=f"{base_path}/assets-gateway/treedb-backend")
+        return TreeDbClient(
+            url_base=f"{base_path}/assets-gateway/treedb-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_flux_client(env: YouwolEnvironment) -> FluxClient:
         base_path = LocalClients.base_path(env)
-        return FluxClient(url_base=f"{base_path}/flux-backend")
+        return FluxClient(
+            url_base=f"{base_path}/flux-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_cdn_client(env: YouwolEnvironment) -> CdnClient:
         base_path = LocalClients.base_path(env)
-        return CdnClient(url_base=f"{base_path}/cdn-backend")
+        return CdnClient(
+            url_base=f"{base_path}/cdn-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_gtw_cdn_client(env: YouwolEnvironment) -> CdnClient:
         base_path = LocalClients.base_path(env)
-        return CdnClient(url_base=f"{base_path}/assets-gateway/cdn-backend")
+        return CdnClient(
+            url_base=f"{base_path}/assets-gateway/cdn-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_stories_client(env: YouwolEnvironment) -> StoriesClient:
         base_path = LocalClients.base_path(env)
-        return StoriesClient(url_base=f"{base_path}/stories-backend")
+        return StoriesClient(
+            url_base=f"{base_path}/stories-backend",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_cdn_sessions_storage_client(
         env: YouwolEnvironment,
     ) -> CdnSessionsStorageClient:
         base_path = LocalClients.base_path(env)
-        return CdnSessionsStorageClient(url_base=f"{base_path}/cdn-sessions-storage")
+        return CdnSessionsStorageClient(
+            url_base=f"{base_path}/cdn-sessions-storage",
+            request_executor=LocalClients.request_executor,
+        )
 
     @staticmethod
     def get_accounts_client(env: YouwolEnvironment) -> AccountsClient:
         base_path = LocalClients.base_path(env)
-        return AccountsClient(url_base=f"{base_path}/accounts")
+        return AccountsClient(
+            url_base=f"{base_path}/accounts",
+            request_executor=LocalClients.request_executor,
+        )

--- a/src/youwol/app/environment/local_auth.py
+++ b/src/youwol/app/environment/local_auth.py
@@ -9,15 +9,6 @@ from typing import Optional, Tuple
 # third parties
 from starlette.requests import Request
 
-# Youwol application
-from youwol.app.environment import (
-    Authentication,
-    AuthorizationProvider,
-    BrowserAuth,
-    DirectAuth,
-)
-from youwol.app.environment.youwol_environment import YouwolEnvironment
-
 # Youwol utilities
 from youwol.utils.clients.oidc.oidc_config import OidcConfig
 from youwol.utils.clients.oidc.tokens_manager import (
@@ -27,6 +18,10 @@ from youwol.utils.clients.oidc.tokens_manager import (
 )
 from youwol.utils.context import Context
 from youwol.utils.middlewares import JwtProvider, JwtProviderBearer, JwtProviderCookie
+
+# relative
+from .models import Authentication, AuthorizationProvider, BrowserAuth, DirectAuth
+from .youwol_environment import YouwolEnvironment
 
 
 class NeedInteractiveSession(RuntimeError):

--- a/src/youwol/app/fastapi_app.py
+++ b/src/youwol/app/fastapi_app.py
@@ -13,15 +13,15 @@ import youwol.app.middlewares.local_cloud_hybridizers as local_cloud_hybridizer
 
 from youwol.app.environment import (
     CustomMiddleware,
+    JwtProviderBearerDynamicIssuer,
+    JwtProviderCookieDynamicIssuer,
+    JwtProviderPyYouwol,
     YouwolEnvironment,
     api_configuration,
     yw_config,
 )
 from youwol.app.middlewares import (
     BrowserCachingMiddleware,
-    JwtProviderBearerDynamicIssuer,
-    JwtProviderCookieDynamicIssuer,
-    JwtProviderPyYouwol,
     LocalCloudHybridizerMiddleware,
 )
 from youwol.app.routers import admin, native_backends

--- a/src/youwol/app/middlewares/__init__.py
+++ b/src/youwol/app/middlewares/__init__.py
@@ -1,5 +1,4 @@
 # relative
 from .browser_caching_middleware import *
 from .hybridizer_middleware import *
-from .local_auth import *
 from .local_cloud_hybridizers import *

--- a/src/youwol/app/middlewares/local_cloud_hybridizers/download_rules.py
+++ b/src/youwol/app/middlewares/local_cloud_hybridizers/download_rules.py
@@ -153,8 +153,8 @@ class UpdateApplication(AbstractLocalCloudDispatch):
             asset_id = base64.urlsafe_b64encode(str.encode(package_name)).decode()
 
             env: YouwolEnvironment = await context.get("env", YouwolEnvironment)
-            remote_assets_gtw = await RemoteClients.get_assets_gateway_client(
-                env.get_remote_info().host
+            remote_assets_gtw = await RemoteClients.get_twin_assets_gateway_client(
+                env=env
             )
             remote_cdn = remote_assets_gtw.get_cdn_backend_router()
             local_cdn = LocalClients.get_cdn_client(env=env)

--- a/src/youwol/app/middlewares/local_cloud_hybridizers/download_rules.py
+++ b/src/youwol/app/middlewares/local_cloud_hybridizers/download_rules.py
@@ -208,7 +208,7 @@ class UpdateApplication(AbstractLocalCloudDispatch):
                     version=latest_remote,
                     rest_of_path="",
                     headers=ctx.headers(),
-                    reader=aiohttp_to_starlette_response,
+                    custom_reader=aiohttp_to_starlette_response,
                 )
             )
             return resp

--- a/src/youwol/app/middlewares/local_cloud_hybridizers/download_rules.py
+++ b/src/youwol/app/middlewares/local_cloud_hybridizers/download_rules.py
@@ -209,7 +209,6 @@ class UpdateApplication(AbstractLocalCloudDispatch):
                     rest_of_path="",
                     headers=ctx.headers(),
                     reader=aiohttp_to_starlette_response,
-                    auto_decompress=False,
                 )
             )
             return resp

--- a/src/youwol/app/middlewares/local_cloud_hybridizers/workspace_explorer_rules.py
+++ b/src/youwol/app/middlewares/local_cloud_hybridizers/workspace_explorer_rules.py
@@ -78,9 +78,7 @@ class GetChildrenDispatch(AbstractLocalCloudDispatch):
                 )
                 await ensure_local_path(folder_id=folder_id, env=env, context=ctx)
 
-            assets_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=env.get_remote_info().host
-            )
+            assets_gtw = await RemoteClients.get_twin_assets_gateway_client(env=env)
             remote_gtw_treedb = assets_gtw.get_treedb_backend_router()
 
             local_resp, remote_resp = await asyncio.gather(

--- a/src/youwol/app/routers/commons.py
+++ b/src/youwol/app/routers/commons.py
@@ -104,9 +104,7 @@ async def ensure_local_path(folder_id: str, env: YouwolEnvironment, context: Con
             )
         except HTTPException as e:
             if e.status_code == 404:
-                assets_gtw = await RemoteClients.get_assets_gateway_client(
-                    remote_host=env.get_remote_info().host
-                )
+                assets_gtw = await RemoteClients.get_twin_assets_gateway_client(env=env)
                 remote_treedb = assets_gtw.get_treedb_backend_router()
                 path = await remote_treedb.get_path_folder(
                     folder_id=folder_id, headers=context.headers()

--- a/src/youwol/app/routers/environment/download_assets/common.py
+++ b/src/youwol/app/routers/environment/download_assets/common.py
@@ -190,9 +190,7 @@ async def create_asset_local(
         action=f"Sync. asset {asset_id} of kind {kind}",
     ) as ctx:
         env: YouwolEnvironment = await ctx.get("env", YouwolEnvironment)
-        remote_gtw = await RemoteClients.get_assets_gateway_client(
-            remote_host=env.get_remote_info().host
-        )
+        remote_gtw = await RemoteClients.get_twin_assets_gateway_client(env=env)
         await sync_raw_data(
             asset_id=asset_id, remote_gtw=remote_gtw, caller_context=ctx
         )

--- a/src/youwol/app/routers/environment/router.py
+++ b/src/youwol/app/routers/environment/router.py
@@ -25,6 +25,7 @@ from youwol.app.environment import (
     FwdArgumentsReload,
     PathsBook,
     Projects,
+    RemoteClients,
     YouwolEnvironment,
     YouwolEnvironmentFactory,
     get_connected_local_tokens,
@@ -231,7 +232,9 @@ async def upload(
         with_reporters=[LogsStreamer()],
     ) as ctx:
         return await upload_asset(
-            remote_host=config.get_remote_info().host,
+            remote_assets_gtw=await RemoteClients.get_twin_assets_gateway_client(
+                env=config
+            ),
             asset_id=asset_id,
             options=None,
             context=ctx,

--- a/src/youwol/app/routers/environment/router.py
+++ b/src/youwol/app/routers/environment/router.py
@@ -27,10 +27,10 @@ from youwol.app.environment import (
     Projects,
     YouwolEnvironment,
     YouwolEnvironmentFactory,
+    get_connected_local_tokens,
     yw_config,
 )
 from youwol.app.environment.models import predefined_configs
-from youwol.app.middlewares import get_connected_local_tokens
 from youwol.app.routers.projects import ProjectLoader
 from youwol.app.web_socket import LogsStreamer
 

--- a/src/youwol/app/routers/environment/upload_assets/custom_asset.py
+++ b/src/youwol/app/routers/environment/upload_assets/custom_asset.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Dict, Tuple
 
 # Youwol application
-from youwol.app.environment import LocalClients, RemoteClients, YouwolEnvironment
+from youwol.app.environment import LocalClients, YouwolEnvironment
 from youwol.app.routers.environment.upload_assets.models import UploadTask
 
 # Youwol utilities
@@ -36,10 +36,7 @@ class UploadCustomAssetTask(UploadTask):
         async with context.start(
             action="UploadDataTask.create_raw"
         ) as ctx:  # type: Context
-            assets_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.remote_host
-            )
-            assets_backend = assets_gtw.get_assets_backend_router()
+            assets_backend = self.remote_assets_gtw.get_assets_backend_router()
             await assets_backend.create_asset(
                 body=data[1], params={"folder-id": folder_id}, headers=ctx.headers()
             )
@@ -53,10 +50,7 @@ class UploadCustomAssetTask(UploadTask):
         async with context.start(
             action="UploadDataTask.update_raw"
         ) as ctx:  # type: Context
-            assets_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.remote_host
-            )
-            assets_backend = assets_gtw.get_assets_backend_router()
+            assets_backend = self.remote_assets_gtw.get_assets_backend_router()
             await assets_backend.add_zip_files(
                 asset_id=self.asset_id, data=data[0], headers=ctx.headers()
             )

--- a/src/youwol/app/routers/environment/upload_assets/data.py
+++ b/src/youwol/app/routers/environment/upload_assets/data.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from aiohttp import FormData
 
 # Youwol application
-from youwol.app.environment import LocalClients, RemoteClients, YouwolEnvironment
+from youwol.app.environment import LocalClients, YouwolEnvironment
 from youwol.app.routers.environment.upload_assets.models import UploadTask
 
 # Youwol utilities
@@ -47,10 +47,7 @@ class UploadDataTask(UploadTask):
         async with context.start(
             action="UploadDataTask.create_raw"
         ) as ctx:  # type: Context
-            assets_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.remote_host
-            )
-            files_client = assets_gtw.get_files_backend_router()
+            files_client = self.remote_assets_gtw.get_files_backend_router()
             await files_client.upload(
                 data=data, params={"folder-id": folder_id}, headers=ctx.headers()
             )
@@ -59,9 +56,6 @@ class UploadDataTask(UploadTask):
         async with context.start(
             action="UploadDataTask.update_raw"
         ) as ctx:  # type: Context
-            remote_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.remote_host
-            )
-            await remote_gtw.get_files_backend_router().upload(
+            await self.remote_assets_gtw.get_files_backend_router().upload(
                 data=data, headers=ctx.headers()
             )

--- a/src/youwol/app/routers/environment/upload_assets/flux_project.py
+++ b/src/youwol/app/routers/environment/upload_assets/flux_project.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 
 # Youwol application
-from youwol.app.environment import LocalClients, RemoteClients, YouwolEnvironment
+from youwol.app.environment import LocalClients, YouwolEnvironment
 from youwol.app.routers.environment.upload_assets.models import UploadTask
 
 # Youwol backends
@@ -34,10 +34,7 @@ class UploadFluxProjectTask(UploadTask):
         ) as ctx:  # type: Context
             data["projectId"] = self.raw_id
             zipped = zip_project(project=data)
-            remote_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.remote_host
-            )
-            await remote_gtw.get_flux_backend_router().upload_project(
+            await self.remote_assets_gtw.get_flux_backend_router().upload_project(
                 project_id=self.raw_id,
                 data={"file": zipped, "content_encoding": "identity"},
                 params={"folder-id": folder_id},
@@ -49,10 +46,7 @@ class UploadFluxProjectTask(UploadTask):
         async with context.start(
             "UploadFluxProjectTask.update_raw"
         ) as ctx:  # type: Context
-            remote_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.remote_host
-            )
-            flux_client = remote_gtw.get_flux_backend_router()
+            flux_client = self.remote_assets_gtw.get_flux_backend_router()
             await flux_client.update_project(
                 project_id=self.raw_id, body=data, headers=ctx.headers()
             )

--- a/src/youwol/app/routers/environment/upload_assets/models.py
+++ b/src/youwol/app/routers/environment/upload_assets/models.py
@@ -6,12 +6,13 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 # Youwol utilities
+from youwol.utils.clients.assets_gateway.assets_gateway import AssetsGatewayClient
 from youwol.utils.context import Context
 
 
 @dataclass
 class UploadTask(ABC):
-    remote_host: str
+    remote_assets_gtw: AssetsGatewayClient
     raw_id: str
     asset_id: str
     options: Optional[Any] = None

--- a/src/youwol/app/routers/environment/upload_assets/story.py
+++ b/src/youwol/app/routers/environment/upload_assets/story.py
@@ -7,11 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 # Youwol application
-from youwol.app.environment.clients import (
-    LocalClients,
-    RemoteClients,
-    YouwolEnvironment,
-)
+from youwol.app.environment.clients import LocalClients, YouwolEnvironment
 from youwol.app.routers.environment.upload_assets.models import UploadTask
 
 # Youwol utilities
@@ -63,10 +59,7 @@ class UploadStoryTask(UploadTask):
 
     async def create_raw(self, data: bytes, folder_id: str, context: Context):
         async with context.start("UploadStoryTask.create_raw") as ctx:  # type: Context
-            remote_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.remote_host
-            )
-            stories_client = remote_gtw.get_stories_backend_router()
+            stories_client = self.remote_assets_gtw.get_stories_backend_router()
             await stories_client.publish_story(
                 data={"file": data, "content_encoding": "identity"},
                 params={"folder-id": folder_id},
@@ -76,10 +69,7 @@ class UploadStoryTask(UploadTask):
     async def update_raw(self, data: JSON, folder_id: str, context: Context):
         # <!> stories_client will be removed as it should not be available
         async with context.start("UploadStoryTask.update_raw") as ctx:  # type: Context
-            remote_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.remote_host
-            )
-            stories_client = remote_gtw.get_stories_backend_router()
+            stories_client = self.remote_assets_gtw.get_stories_backend_router()
             await stories_client.publish_story(
                 data={"file": data, "content_encoding": "identity"},
                 headers=ctx.headers(),

--- a/src/youwol/app/routers/local_cdn/implementation.py
+++ b/src/youwol/app/routers/local_cdn/implementation.py
@@ -71,9 +71,7 @@ def get_latest_local_cdn_version(env: YouwolEnvironment) -> List[TargetPackage]:
 
 async def check_update(local_package: TargetPackage, context: Context):
     env: YouwolEnvironment = await context.get("env", YouwolEnvironment)
-    remote_gtw_client = await RemoteClients.get_assets_gateway_client(
-        remote_host=env.get_remote_info().host
-    )
+    remote_gtw_client = await RemoteClients.get_twin_assets_gateway_client(env)
     headers = {"authorization": context.headers().get("authorization")}
     name, version = local_package.library_name, local_package.version
     async with context.start(

--- a/src/youwol/app/routers/native_backends_config.py
+++ b/src/youwol/app/routers/native_backends_config.py
@@ -1,4 +1,5 @@
 # Youwol application
+from youwol.app.environment.local_auth import local_tokens_id
 from youwol.app.environment.youwol_environment import yw_config
 
 # Youwol backends
@@ -7,9 +8,6 @@ import youwol.backends.accounts
 # Youwol utilities
 from youwol.utils import CacheClient, OidcConfig
 from youwol.utils.context import ContextFactory
-
-# relative
-from ..middlewares.local_auth import local_tokens_id
 
 
 async def cdn_config_py_youwol():

--- a/src/youwol/backends/assets_gateway/deployment.py
+++ b/src/youwol/backends/assets_gateway/deployment.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter
 from youwol.backends.assets_gateway import Configuration, get_router
 from youwol.backends.common import BackendDeployment
 from youwol.backends.common.app import get_fastapi_app
-from youwol.backends.common.clients import cdn_client
+from youwol.backends.common.clients import cdn_client, request_executor
 from youwol.backends.common.use_auth_middleware_with_cookie import (
     get_auth_middleware_with_cookie,
 )
@@ -26,12 +26,27 @@ class AssetsGatewayDeployment(BackendDeployment):
     def router(self) -> APIRouter:
         return get_router(
             Configuration(
-                assets_client=AssetsClient(url_base="http://assets/api/assets"),
+                assets_client=AssetsClient(
+                    url_base="http://assets/api/assets",
+                    request_executor=request_executor(),
+                ),
                 cdn_client=cdn_client,
-                files_client=FilesClient(url_base="http://files/api/files"),
-                flux_client=FluxClient("http://flux/api/flux"),
-                stories_client=StoriesClient(url_base="http://stories/api/stories"),
-                treedb_client=TreeDbClient(url_base="http://tree-db/api/tree-db"),
+                files_client=FilesClient(
+                    url_base="http://files/api/files",
+                    request_executor=request_executor(),
+                ),
+                flux_client=FluxClient(
+                    "http://flux/api/flux",
+                    request_executor=request_executor(),
+                ),
+                stories_client=StoriesClient(
+                    url_base="http://stories/api/stories",
+                    request_executor=request_executor(),
+                ),
+                treedb_client=TreeDbClient(
+                    url_base="http://tree-db/api/tree-db",
+                    request_executor=request_executor(),
+                ),
                 https=True,
             )
         )

--- a/src/youwol/backends/assets_gateway/routers/assets_backend.py
+++ b/src/youwol/backends/assets_gateway/routers/assets_backend.py
@@ -144,7 +144,7 @@ async def get_file(
         return await assets_db.get_file(
             asset_id=asset_id,
             path=rest_of_path,
-            reader=aiohttp_to_starlette_response,
+            custom_reader=aiohttp_to_starlette_response,
             headers=ctx.headers(from_req_fwd=lambda header_keys: header_keys),
         )
 

--- a/src/youwol/backends/assets_gateway/routers/cdn_backend.py
+++ b/src/youwol/backends/assets_gateway/routers/cdn_backend.py
@@ -205,7 +205,6 @@ async def get_entry_point(
             library_id=library_id,
             version=version,
             reader=aiohttp_to_starlette_response,
-            auto_decompress=False,
             headers=ctx.headers(from_req_fwd=lambda header_keys: header_keys),
         )
 
@@ -236,7 +235,6 @@ async def get_resource(
             version=version,
             rest_of_path=rest_of_path,
             reader=aiohttp_to_starlette_response,
-            auto_decompress=False,
             headers=ctx.headers(),
         )
 

--- a/src/youwol/backends/assets_gateway/routers/cdn_backend.py
+++ b/src/youwol/backends/assets_gateway/routers/cdn_backend.py
@@ -204,7 +204,7 @@ async def get_entry_point(
         return await configuration.cdn_client.get_entry_point(
             library_id=library_id,
             version=version,
-            reader=aiohttp_to_starlette_response,
+            custom_reader=aiohttp_to_starlette_response,
             headers=ctx.headers(from_req_fwd=lambda header_keys: header_keys),
         )
 
@@ -234,7 +234,7 @@ async def get_resource(
             library_id=library_id,
             version=version,
             rest_of_path=rest_of_path,
-            reader=aiohttp_to_starlette_response,
+            custom_reader=aiohttp_to_starlette_response,
             headers=ctx.headers(),
         )
 

--- a/src/youwol/backends/assets_gateway/routers/deprecated.py
+++ b/src/youwol/backends/assets_gateway/routers/deprecated.py
@@ -61,7 +61,7 @@ async def get_raw_package(
             library_id=raw_id,
             version=version,
             rest_of_path=rest_of_path,
-            reader=aiohttp_to_starlette_response,
+            custom_reader=aiohttp_to_starlette_response,
             headers=ctx.headers(),
         )
 

--- a/src/youwol/backends/assets_gateway/routers/deprecated.py
+++ b/src/youwol/backends/assets_gateway/routers/deprecated.py
@@ -62,7 +62,6 @@ async def get_raw_package(
             version=version,
             rest_of_path=rest_of_path,
             reader=aiohttp_to_starlette_response,
-            auto_decompress=False,
             headers=ctx.headers(),
         )
 

--- a/src/youwol/backends/common/clients.py
+++ b/src/youwol/backends/common/clients.py
@@ -1,8 +1,21 @@
+# third parties
+import aiohttp
+
 # Youwol utilities
-from youwol.utils import CdnClient
+from youwol.utils import AioHttpExecutor, CdnClient
 from youwol.utils.clients.assets_gateway.assets_gateway import AssetsGatewayClient
 
-cdn_client = CdnClient(url_base="http://cdn/api/cdn")
+
+def request_executor():
+    return AioHttpExecutor(
+        client_session=lambda: aiohttp.ClientSession(auto_decompress=False)
+    )
+
+
+cdn_client = CdnClient(
+    url_base="http://cdn/api/cdn", request_executor=request_executor()
+)
 assets_gateway_client = AssetsGatewayClient(
-    url_base="http://assets-gateway/api/assets-gateway"
+    url_base="http://assets-gateway/api/assets-gateway",
+    request_executor=request_executor(),
 )

--- a/src/youwol/pipelines/publish_cdn.py
+++ b/src/youwol/pipelines/publish_cdn.py
@@ -21,7 +21,7 @@ from youwol.app.environment import (
     RemoteClients,
     YouwolEnvironment,
 )
-from youwol.app.middlewares.local_auth import get_local_tokens
+from youwol.app.environment.local_auth import get_local_tokens
 from youwol.app.routers.environment.upload_assets.package import UploadPackageOptions
 from youwol.app.routers.environment.upload_assets.upload import upload_asset
 from youwol.app.routers.local_cdn import download_package

--- a/src/youwol/pipelines/publish_cdn.py
+++ b/src/youwol/pipelines/publish_cdn.py
@@ -21,7 +21,6 @@ from youwol.app.environment import (
     RemoteClients,
     YouwolEnvironment,
 )
-from youwol.app.environment.local_auth import get_local_tokens
 from youwol.app.routers.environment.upload_assets.package import UploadPackageOptions
 from youwol.app.routers.environment.upload_assets.upload import upload_asset
 from youwol.app.routers.local_cdn import download_package
@@ -398,31 +397,6 @@ class PublishCdnRemoteStep(PipelineStep):
     cdnTarget: CdnTarget
     run: ExplicitNone = ExplicitNone()
 
-    async def get_access_token(self, context: Context):
-        env: YouwolEnvironment = await context.get("env", YouwolEnvironment)
-        try:
-            authentication = next(
-                auth
-                for auth in self.cdnTarget.cloudTarget.authentications
-                if auth.authId == self.cdnTarget.authId
-            )
-        except StopIteration as e:
-            await context.error(
-                text=f"Can no find auth {self.cdnTarget.authId} in cloud target's authentications",
-                data={"cloud target": self.cdnTarget.cloudTarget},
-            )
-            raise e
-
-        tokens = await get_local_tokens(
-            tokens_storage=env.tokens_storage,
-            auth_provider=self.cdnTarget.cloudTarget.authProvider,
-            auth_infos=authentication,
-        )
-
-        access_token = await tokens.access_token()
-
-        return f"Bearer {access_token}"
-
     async def get_status(
         self,
         project: Project,
@@ -430,18 +404,15 @@ class PublishCdnRemoteStep(PipelineStep):
         last_manifest: Optional[Manifest],
         context: Context,
     ) -> PipelineStepStatus:
-        access_token = await self.get_access_token(context=context)
-
         async with context.start(
-            action="PublishCdnRemoteStep.get_status",
-            with_headers={
-                "Authorization": access_token,
-            },
+            action="PublishCdnRemoteStep.get_status"
         ) as ctx:  # type: Context
             env = await context.get("env", YouwolEnvironment)
             local_cdn = LocalClients.get_cdn_client(env=env)
             remote_gtw = await RemoteClients.get_assets_gateway_client(
-                remote_host=self.cdnTarget.cloudTarget.host
+                cloud_environment=self.cdnTarget.cloudTarget,
+                auth_id=self.cdnTarget.authId,
+                tokens_storage=env.tokens_storage,
             )
             remote_cdn = remote_gtw.get_cdn_backend_router()
             library_id = encode_id(project.publishName)
@@ -496,16 +467,18 @@ class PublishCdnRemoteStep(PipelineStep):
     async def execute_run(self, project: Project, flow_id: str, context: Context):
         env: YouwolEnvironment = await context.get("env", YouwolEnvironment)
 
-        access_token = await self.get_access_token(context=context)
-
         async with context.start(
             action="PublishCdnRemoteStep.execute_run",
-            with_headers={"Authorization": access_token},
         ) as ctx:
             options = UploadPackageOptions(versions=[project.version])
             package_id = encode_id(project.publishName)
+            remote_assets_gtw = await RemoteClients.get_assets_gateway_client(
+                cloud_environment=self.cdnTarget.cloudTarget,
+                auth_id=self.cdnTarget.authId,
+                tokens_storage=env.tokens_storage,
+            )
             await upload_asset(
-                remote_host=self.cdnTarget.cloudTarget.host,
+                remote_assets_gtw=remote_assets_gtw,
                 asset_id=encode_id(package_id),
                 options=options,
                 context=ctx,

--- a/src/youwol/utils/admin/visitors_cleaning.py
+++ b/src/youwol/utils/admin/visitors_cleaning.py
@@ -5,9 +5,12 @@ import asyncio
 from typing import List
 
 # third parties
+import aiohttp
+
 from pydantic import BaseModel
 
 # Youwol utilities
+from youwol.utils import AioHttpExecutor
 from youwol.utils.clients.oidc.oidc_config import (
     OidcConfig,
     OidcForClient,
@@ -107,7 +110,10 @@ async def clean_drive(drive: Drive, treedb: TreeDbClient, context: Context):
 async def clean_visitors(body: CleanVisitorsBody, context: Context):
     async with context.start(action="clean_visitors") as ctx:  # type: Context
         treedb = TreeDbClient(
-            url_base="https://platform.youwol.com/api/assets-gateway/treedb-backend"
+            url_base="https://platform.youwol.com/api/assets-gateway/treedb-backend",
+            request_executor=AioHttpExecutor(
+                client_session=lambda: aiohttp.ClientSession(auto_decompress=False)
+            ),
         )
         openid_config = OidcConfig(body.base_url)
         private_client = PrivateClient(

--- a/src/youwol/utils/clients/__init__.py
+++ b/src/youwol/utils/clients/__init__.py
@@ -5,6 +5,7 @@ from .cdn import *
 from .docdb import *
 from .file_system import *
 from .oidc import *
+from .request_executor import *
 from .storage import *
 from .types import *
 from .utils import *

--- a/src/youwol/utils/clients/accounts/accounts.py
+++ b/src/youwol/utils/clients/accounts/accounts.py
@@ -1,38 +1,26 @@
 # standard library
-from dataclasses import dataclass, field
-
-# typing
-from typing import Dict
-
-# third parties
-import aiohttp
+from dataclasses import dataclass
 
 # Youwol utilities
-from youwol.utils.exceptions import raise_exception_from_response
+from youwol.utils.clients.request_executor import RequestExecutor, json_reader
 
 
 @dataclass(frozen=True)
 class AccountsClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
-    connector = aiohttp.TCPConnector(verify_ssl=False)
+    request_executor: RequestExecutor
 
     async def healthz(self, **kwargs):
-        url = f"{self.url_base}/healthz"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/healthz",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_session_details(self, **kwargs):
-        url = f"{self.url_base}/session"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/session",
+            default_reader=json_reader,
+            **kwargs,
+        )

--- a/src/youwol/utils/clients/assets/assets.py
+++ b/src/youwol/utils/clients/assets/assets.py
@@ -11,11 +11,11 @@ from aiohttp import ClientResponse, FormData
 # Youwol utilities
 from youwol.utils.clients.request_executor import (
     RequestExecutor,
+    auto_reader,
     bytes_reader,
     json_reader,
 )
 from youwol.utils.exceptions import raise_exception_from_response
-from youwol.utils.utils_requests import extract_aiohttp_response
 
 
 @dataclass(frozen=True)
@@ -56,17 +56,11 @@ class AssetsClient:
         self,
         asset_id: str,
         path: Union[Path, str],
-        reader: Callable[[ClientResponse], Awaitable[Any]] = None,
         **kwargs,
     ):
-        async def _reader(resp: ClientResponse):
-            if resp.status < 300:
-                return await extract_aiohttp_response(resp=resp, reader=reader)
-            await raise_exception_from_response(resp, **kwargs)
-
         return await self.request_executor.get(
             url=f"{self.url_base}/assets/{asset_id}/files/{path}",
-            default_reader=_reader,
+            default_reader=auto_reader,
             **kwargs,
         )
 

--- a/src/youwol/utils/clients/assets/assets.py
+++ b/src/youwol/utils/clients/assets/assets.py
@@ -1,16 +1,19 @@
 # standard library
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 # typing
-from typing import Any, Awaitable, Callable, Dict, Union
+from typing import Any, Awaitable, Callable, Union
 
 # third parties
-import aiohttp
-
 from aiohttp import ClientResponse, FormData
 
 # Youwol utilities
+from youwol.utils.clients.request_executor import (
+    RequestExecutor,
+    bytes_reader,
+    json_reader,
+)
 from youwol.utils.exceptions import raise_exception_from_response
 from youwol.utils.utils_requests import extract_aiohttp_response
 
@@ -19,31 +22,22 @@ from youwol.utils.utils_requests import extract_aiohttp_response
 class AssetsClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
-    connector = aiohttp.TCPConnector(verify_ssl=False)
+    request_executor: RequestExecutor
 
     async def healthz(self, **kwargs):
-        url = f"{self.url_base}/healthz"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/healthz", default_reader=json_reader, **kwargs
+        )
 
     async def create_asset(self, body, **kwargs):
-        url = f"{self.url_base}/assets"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.put(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.put(
+            url=f"{self.url_base}/assets",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def add_zip_files(self, asset_id: str, data: bytes, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/files"
         form_data = FormData()
         form_data.add_field(
             "file",
@@ -51,14 +45,12 @@ class AssetsClient:
             filename="zipped-files.zip",
             content_type="application/octet-stream",
         )
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, data=form_data, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/assets/{asset_id}/files",
+            default_reader=json_reader,
+            data=form_data,
+            **kwargs,
+        )
 
     async def get_file(
         self,
@@ -67,87 +59,73 @@ class AssetsClient:
         reader: Callable[[ClientResponse], Awaitable[Any]] = None,
         **kwargs,
     ):
-        url = f"{self.url_base}/assets/{asset_id}/files/{path}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status < 300:
-                    return await extract_aiohttp_response(resp=resp, reader=reader)
-                await raise_exception_from_response(resp, **kwargs)
+        async def _reader(resp: ClientResponse):
+            if resp.status < 300:
+                return await extract_aiohttp_response(resp=resp, reader=reader)
+            await raise_exception_from_response(resp, **kwargs)
+
+        return await self.request_executor.get(
+            url=f"{self.url_base}/assets/{asset_id}/files/{path}",
+            default_reader=_reader,
+            **kwargs,
+        )
 
     async def delete_files(self, asset_id: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/files"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/assets/{asset_id}/files",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_zip_files(self, asset_id: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/files"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.read()
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/assets/{asset_id}/files",
+            default_reader=bytes_reader,
+            **kwargs,
+        )
 
     async def update_asset(self, asset_id: str, body, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/assets/{asset_id}",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def put_access_policy(self, asset_id: str, group_id: str, body, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/access/{group_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.put(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.put(
+            url=f"{self.url_base}/assets/{asset_id}/access/{group_id}",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def delete_access_policy(self, asset_id: str, group_id: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/access/{group_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/assets/{asset_id}/access/{group_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def post_image(self, asset_id: str, filename: str, src: bytes, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/images/{filename}"
         form_data = FormData()
         form_data.add_field(
             "file", src, filename=filename, content_type="application/octet-stream"
         )
 
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, data=form_data, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/assets/{asset_id}/images/{filename}",
+            default_reader=json_reader,
+            data=form_data,
+            **kwargs,
+        )
 
     async def remove_image(self, asset_id: str, filename: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/images/{filename}"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/assets/{asset_id}/images/{filename}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_media(
         self,
@@ -157,106 +135,85 @@ class AssetsClient:
         reader: Callable[[ClientResponse], Awaitable[Any]] = None,
         **kwargs,
     ):
-        url = f"{self.url_base}/assets/{asset_id}/{media_type}/{name}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    if reader:
-                        return await reader(resp)
-                    return resp.read()
+        async def _reader(resp: ClientResponse):
+            if resp.status == 200:
+                if reader:
+                    return await reader(resp)
+                return resp.read()
 
-                await raise_exception_from_response(resp, **kwargs)
+            await raise_exception_from_response(resp, **kwargs)
+
+        return await self.request_executor.get(
+            url=f"{self.url_base}/assets/{asset_id}/{media_type}/{name}",
+            default_reader=_reader,
+            **kwargs,
+        )
 
     async def query(self, body, **kwargs):
-        url = f"{self.url_base}/query"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/query",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def get(self, asset_id: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/assets/{asset_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_asset(self, asset_id: str, **kwargs):
         return await self.get(asset_id=asset_id, **kwargs)
 
     async def delete_asset(self, asset_id: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/assets/{asset_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_access_policy(self, asset_id: str, group_id: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/access/{group_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/assets/{asset_id}/access/{group_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_permissions(self, asset_id: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/permissions"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/assets/{asset_id}/permissions",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_access_info(self, asset_id: str, **kwargs):
-        url = f"{self.url_base}/assets/{asset_id}/access-info"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/assets/{asset_id}/access-info",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_records(self, body, **kwargs):
-        url = f"{self.url_base}/records"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/records",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def record_access(self, raw_id: str, **kwargs):
-        url = f"{self.url_base}/raw/access/{raw_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.put(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.put(
+            url=f"{self.url_base}/raw/access/{raw_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def query_latest_access(self, asset_id: str, max_count=100, **kwargs):
-        url = f"{self.url_base}/raw/access/{asset_id}/query-latest"
-        params = {"max-count": max_count}
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, params=params, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/raw/access/{asset_id}/query-latest",
+            default_reader=json_reader,
+            params={"max-count": max_count},
+            **kwargs,
+        )

--- a/src/youwol/utils/clients/assets_gateway/assets_gateway.py
+++ b/src/youwol/utils/clients/assets_gateway/assets_gateway.py
@@ -1,27 +1,23 @@
 # standard library
-from dataclasses import dataclass, field
-
-# typing
-from typing import Dict
+from dataclasses import dataclass
 
 # third parties
 import aiohttp
 
 # Youwol utilities
-from youwol.utils import CdnClient
+from youwol.utils import CdnClient, RequestExecutor, json_reader
 from youwol.utils.clients.assets.assets import AssetsClient
 from youwol.utils.clients.files import FilesClient
 from youwol.utils.clients.flux.flux import FluxClient
 from youwol.utils.clients.stories.stories import StoriesClient
 from youwol.utils.clients.treedb.treedb import TreeDbClient
-from youwol.utils.exceptions import raise_exception_from_response
 
 
 @dataclass(frozen=True)
 class AssetsGatewayClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
+    request_executor: RequestExecutor
 
     @staticmethod
     def get_aiohttp_connector():
@@ -29,38 +25,43 @@ class AssetsGatewayClient:
 
     def get_assets_backend_router(self) -> AssetsClient:
         return AssetsClient(
-            url_base=f"{self.url_base}/assets-backend", headers=self.headers
+            url_base=f"{self.url_base}/assets-backend",
+            request_executor=self.request_executor,
         )
 
     def get_treedb_backend_router(self) -> TreeDbClient:
         return TreeDbClient(
-            url_base=f"{self.url_base}/treedb-backend", headers=self.headers
+            url_base=f"{self.url_base}/treedb-backend",
+            request_executor=self.request_executor,
         )
 
     def get_files_backend_router(self) -> FilesClient:
         return FilesClient(
-            url_base=f"{self.url_base}/files-backend", headers=self.headers
+            url_base=f"{self.url_base}/files-backend",
+            request_executor=self.request_executor,
         )
 
     def get_flux_backend_router(self) -> FluxClient:
         return FluxClient(
-            url_base=f"{self.url_base}/flux-backend", headers=self.headers
+            url_base=f"{self.url_base}/flux-backend",
+            request_executor=self.request_executor,
         )
 
     def get_stories_backend_router(self) -> StoriesClient:
         return StoriesClient(
-            url_base=f"{self.url_base}/stories-backend", headers=self.headers
+            url_base=f"{self.url_base}/stories-backend",
+            request_executor=self.request_executor,
         )
 
     def get_cdn_backend_router(self) -> CdnClient:
-        return CdnClient(url_base=f"{self.url_base}/cdn-backend", headers=self.headers)
+        return CdnClient(
+            url_base=f"{self.url_base}/cdn-backend",
+            request_executor=self.request_executor,
+        )
 
     async def healthz(self, **kwargs):
-        url = f"{self.url_base}/healthz"
-        async with aiohttp.ClientSession(
-            connector=self.get_aiohttp_connector(), headers=self.headers
-        ) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/healthz",
+            default_reader=json_reader,
+            **kwargs,
+        )

--- a/src/youwol/utils/clients/cdn/cdn.py
+++ b/src/youwol/utils/clients/cdn/cdn.py
@@ -2,18 +2,21 @@
 import functools
 import hashlib
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 # typing
-from typing import Any, Awaitable, Callable, Dict, Iterable, List, Union
+from typing import Any, Awaitable, Callable, Iterable, List, Union
 
 # third parties
-import aiohttp
-
 from aiohttp import ClientResponse, FormData
 
 # Youwol utilities
+from youwol.utils.clients.request_executor import (
+    RequestExecutor,
+    bytes_reader,
+    json_reader,
+)
 from youwol.utils.exceptions import raise_exception_from_response
 from youwol.utils.utils_requests import extract_aiohttp_response
 
@@ -39,7 +42,7 @@ def files_check_sum(paths: Iterable[Path]):
 class CdnClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
+    request_executor: RequestExecutor
 
     @property
     def packs_url(self):
@@ -75,55 +78,41 @@ class CdnClient:
             if not namespace
             else f"{self.packs_url}?namespace={namespace}"
         )
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=self.packs_url, headers=self.headers
-                )
+        return await self.request_executor.get(
+            url=url,
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def query_libraries(self, **kwargs):
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=self.libraries_url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=self.libraries_url, headers=self.headers
-                )
+        return await self.request_executor.get(
+            url=self.libraries_url,
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def query_dependencies_latest(self, libraries: List[str], **kwargs):
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                url=self.dependencies_url, json={"libraries": libraries}, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=self.dependencies_url, headers=self.headers
-                )
+        return await self.request_executor.post(
+            url=self.dependencies_url,
+            default_reader=json_reader,
+            json={"libraries": libraries},
+            **kwargs,
+        )
 
     async def query_loading_graph(self, body: any, **kwargs):
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                url=self.loading_graph_url, json=body, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=self.loading_graph_url, headers=self.headers
-                )
+        return await self.request_executor.post(
+            url=self.loading_graph_url,
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def get_json(self, url: Union[Path, str], **kwargs):
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(
-                url=f"{self.url_base}/{str(url)}", **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=f"{self.url_base}/{str(url)}", headers=self.headers
-                )
+        return await self.request_executor.get(
+            url=f"{self.url_base}/{str(url)}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_library_info(
         self, library_id: str, semver: str = None, max_count: int = None, **kwargs
@@ -138,97 +127,74 @@ class CdnClient:
         )
 
         url = f"{self.url_base}/libraries/{library_id}?{suffix}"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.get(
+            url=url,
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_version_info(self, library_id: str, version: str, **kwargs):
-        url = f"{self.url_base}/libraries/{library_id}/{version}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/libraries/{library_id}/{version}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def publish(self, zip_content: bytes, **kwargs):
         form_data = FormData()
         form_data.add_field(
             "file", zip_content, filename="cdn.zip", content_type="identity"
         )
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                self.publish_url, data=form_data, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=self.publish_url, headers=self.headers
-                )
+        return await self.request_executor.post(
+            url=self.publish_url,
+            data=form_data,
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def download_library(self, library_id: str, version: str, **kwargs):
-        url = f"{self.download_url}/{library_id}/{version}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.read()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.get(
+            url=f"{self.download_url}/{library_id}/{version}",
+            default_reader=bytes_reader,
+            **kwargs,
+        )
 
     async def publish_libraries(self, zip_path: Union[Path, str], **kwargs):
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            with open(zip_path, "rb") as fp:
-                async with await session.post(
-                    self.push_url, data={"file": fp}, **kwargs
-                ) as resp:
-                    if resp.status == 200:
-                        return await resp.json()
-                    await raise_exception_from_response(
-                        resp, url=self.push_url, headers=self.headers
-                    )
+        with open(zip_path, "rb") as fp:
+            return await self.request_executor.post(
+                url=self.push_url,
+                data={"file": fp},
+                default_reader=json_reader,
+                **kwargs,
+            )
 
     async def delete_library(self, library_id: str, **kwargs):
-        url = f"{self.url_base}/libraries/{library_id}"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=self.push_url, headers=self.headers
-                )
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/libraries/{library_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def delete_version(self, library_id: str, version: str, **kwargs):
-        url = f"{self.url_base}/libraries/{library_id}/{version}"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=self.push_url, headers=self.headers
-                )
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/libraries/{library_id}/{version}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_explorer(
         self, library_id: str, version: str, folder_path: str, **kwargs
     ):
-        url = f"{self.url_base}/explorer/{library_id}/{version}/{folder_path}"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(
-                    resp, url=self.push_url, headers=self.headers
-                )
+        return await self.request_executor.get(
+            url=f"{self.url_base}/explorer/{library_id}/{version}/{folder_path}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_entry_point(
         self,
         library_id: str,
         version: str,
-        auto_decompress=True,
         reader: Callable[[ClientResponse], Awaitable[Any]] = None,
         **kwargs,
     ):
@@ -237,7 +203,6 @@ class CdnClient:
             version=version,
             rest_of_path="",
             reader=reader,
-            auto_decompress=auto_decompress,
             **kwargs,
         )
 
@@ -246,7 +211,6 @@ class CdnClient:
         library_id: str,
         version: str,
         rest_of_path: str,
-        auto_decompress=True,
         reader: Callable[[ClientResponse], Awaitable[Any]] = None,
         **kwargs,
     ):
@@ -256,12 +220,13 @@ class CdnClient:
             else f"{self.url_base}/resources/{library_id}/{version}"
         )
 
-        async with aiohttp.ClientSession(
-            headers=self.headers, auto_decompress=auto_decompress
-        ) as session:
-            async with await session.get(url, **kwargs) as resp:
-                if resp.status < 300:
-                    return await extract_aiohttp_response(resp=resp, reader=reader)
-                await raise_exception_from_response(
-                    resp, url=self.push_url, headers=self.headers
-                )
+        async def _reader(resp):
+            if resp.status < 300:
+                return await extract_aiohttp_response(resp=resp, reader=reader)
+            await raise_exception_from_response(resp, url=self.push_url)
+
+        return await self.request_executor.get(
+            url=url,
+            default_reader=_reader,
+            **kwargs,
+        )

--- a/src/youwol/utils/clients/cdn_sessions_storage/cdn_sessions_storage.py
+++ b/src/youwol/utils/clients/cdn_sessions_storage/cdn_sessions_storage.py
@@ -1,38 +1,31 @@
 # standard library
-from dataclasses import dataclass, field
-
-# typing
-from typing import Dict
-
-# third parties
-import aiohttp
+from dataclasses import dataclass
 
 # Youwol utilities
 from youwol.utils import JSON
-from youwol.utils.exceptions import raise_exception_from_response
+from youwol.utils.clients.request_executor import RequestExecutor, json_reader
 
 
 @dataclass(frozen=True)
 class CdnSessionsStorageClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
+    request_executor: RequestExecutor
 
     def base_path(self, package: str, key: str):
         return f"{self.url_base}/applications/{package}/{key}"
 
     async def get(self, package: str, key: str, **kwargs):
-        url = self.base_path(package, key)
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.get(
+            url=self.base_path(package, key),
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def post(self, package: str, key: str, body: JSON, **kwargs):
-        url = self.base_path(package, key)
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.post(
+            url=self.base_path(package, key),
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )

--- a/src/youwol/utils/clients/files/files.py
+++ b/src/youwol/utils/clients/files/files.py
@@ -1,15 +1,14 @@
 # standard library
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 # typing
-from typing import Any, Awaitable, Callable, Dict
+from typing import Any, Awaitable, Callable
 
 # third parties
-import aiohttp
-
 from aiohttp import ClientResponse
 
 # Youwol utilities
+from youwol.utils.clients.request_executor import RequestExecutor, json_reader
 from youwol.utils.exceptions import raise_exception_from_response
 
 
@@ -17,44 +16,37 @@ from youwol.utils.exceptions import raise_exception_from_response
 class FilesClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
+    request_executor: RequestExecutor
 
     async def healthz(self, **kwargs):
-        url = f"{self.url_base}/healthz"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/healthz",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def upload(self, data, **kwargs):
-        url = f"{self.url_base}/files"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, data=data, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/files",
+            default_reader=json_reader,
+            data=data,
+            **kwargs,
+        )
 
     async def get_info(self, file_id: str, **kwargs):
-        url = f"{self.url_base}/files/{file_id}/info"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/files/{file_id}/info",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def update_metadata(self, file_id: str, body, **kwargs):
-        url = f"{self.url_base}/files/{file_id}/metadata"
-        metadata = {k: v for k, v in body.items() if v}
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=metadata, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/files/{file_id}/metadata",
+            default_reader=json_reader,
+            json={k: v for k, v in body.items() if v},
+            **kwargs,
+        )
 
     async def get(
         self,
@@ -64,21 +56,22 @@ class FilesClient:
     ):
         url = f"{self.url_base}/files/{file_id}"
 
-        async with aiohttp.ClientSession(
-            headers=self.headers, auto_decompress=False
-        ) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    if reader:
-                        return await reader(resp)
-                    return await resp.read()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        async def _reader(resp):
+            if resp.status == 200:
+                if reader:
+                    return await reader(resp)
+                return await resp.read()
+            await raise_exception_from_response(resp, url=url)
+
+        return await self.request_executor.get(
+            url=url,
+            default_reader=_reader,
+            **kwargs,
+        )
 
     async def remove(self, file_id: str, **kwargs):
-        url = f"{self.url_base}/files/{file_id}"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.json()
-                await raise_exception_from_response(resp, url=url, headers=self.headers)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/files/{file_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )

--- a/src/youwol/utils/clients/flux/flux.py
+++ b/src/youwol/utils/clients/flux/flux.py
@@ -1,143 +1,110 @@
 # standard library
-from dataclasses import dataclass, field
-
-# typing
-from typing import Dict
-
-# third parties
-import aiohttp
+from dataclasses import dataclass
 
 # Youwol utilities
-from youwol.utils.exceptions import raise_exception_from_response
+from youwol.utils.clients.request_executor import (
+    RequestExecutor,
+    bytes_reader,
+    json_reader,
+)
 
 
 @dataclass(frozen=True)
 class FluxClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
-    connector = aiohttp.TCPConnector(verify_ssl=False)
+    request_executor: RequestExecutor
 
     async def get_projects(self, **kwargs):
-        url = f"{self.url_base}/projects"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/projects",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def create_project(self, body, **kwargs):
-        url = f"{self.url_base}/projects/create"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/projects/create",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def upload_project(self, data, project_id: str = None, **kwargs):
-        url = f"{self.url_base}/projects/upload"
         params = kwargs["params"] if "params" in kwargs else {}
         params = {**params, "project-id": project_id} if project_id else params
         kwargs["params"] = params
 
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, data=data, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/projects/upload",
+            default_reader=json_reader,
+            data=data,
+            **kwargs,
+        )
 
     async def download_zip(self, project_id: str = None, **kwargs):
-        url = f"{self.url_base}/projects/{project_id}/download-zip"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.read()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/projects/{project_id}/download-zip",
+            default_reader=bytes_reader,
+            **kwargs,
+        )
 
     async def update_project(self, project_id, body, **kwargs):
-        url = f"{self.url_base}/projects/{project_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/projects/{project_id}",
+            json=body,
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_project(self, project_id: str, **kwargs):
-        url = f"{self.url_base}/projects/{project_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/projects/{project_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def delete_project(self, project_id: str, **kwargs):
-        url = f"{self.url_base}/projects/{project_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/projects/{project_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_records(self, body, **kwargs):
-        url = f"{self.url_base}/records"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/records",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def update_metadata(self, project_id: str, body, **kwargs):
-        url = f"{self.url_base}/projects/{project_id}/metadata"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/projects/{project_id}/metadata",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def get_metadata(self, project_id: str, **kwargs):
-        url = f"{self.url_base}/projects/{project_id}/metadata"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/projects/{project_id}/metadata",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def duplicate(self, project_id: str, **kwargs):
-        url = f"{self.url_base}/projects/{project_id}/duplicate"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/projects/{project_id}/duplicate",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def publish_application(self, project_id: str, body, **kwargs):
-        url = f"{self.url_base}/projects/{project_id}/publish-application"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/projects/{project_id}/publish-application",
+            json=body,
+            default_reader=json_reader,
+            **kwargs,
+        )

--- a/src/youwol/utils/clients/request_executor.py
+++ b/src/youwol/utils/clients/request_executor.py
@@ -178,24 +178,24 @@ class AioHttpExecutor(RequestExecutor[ClientResponse]):
 
 
 async def text_reader(resp: ClientResponse) -> str:
-    if resp.status == 200:
+    if resp.status < 300:
         resp_text = await resp.text()
         return resp_text
 
-    await raise_exception_from_response(resp)
+    await raise_exception_from_response(resp, url=resp.url)
 
 
 async def json_reader(resp: ClientResponse) -> JSON:
-    if resp.status == 200:
+    if resp.status < 300:
         resp_json = await resp.json()
         return resp_json
 
-    await raise_exception_from_response(resp)
+    await raise_exception_from_response(resp, url=resp.url)
 
 
 async def bytes_reader(resp: ClientResponse) -> bytes:
-    if resp.status == 200:
+    if resp.status < 300:
         resp_bytes = await resp.read()
         return resp_bytes
 
-    await raise_exception_from_response(resp)
+    await raise_exception_from_response(resp, url=resp.url)

--- a/src/youwol/utils/clients/request_executor.py
+++ b/src/youwol/utils/clients/request_executor.py
@@ -199,3 +199,21 @@ async def bytes_reader(resp: ClientResponse) -> bytes:
         return resp_bytes
 
     await raise_exception_from_response(resp, url=resp.url)
+
+
+async def auto_reader(resp: ClientResponse) -> Union[JSON, str, bytes]:
+    if resp.status < 300:
+        content_type = resp.content_type
+
+        if content_type == "application/json":
+            return await resp.json()
+
+        text_applications = ["rtf", "xml", "x-sh"]
+        if content_type.startswith("text/") or content_type in [
+            f"application/{app}" for app in text_applications
+        ]:
+            return await resp.text()
+
+        return await resp.read()
+
+    await raise_exception_from_response(resp)

--- a/src/youwol/utils/clients/request_executor.py
+++ b/src/youwol/utils/clients/request_executor.py
@@ -1,0 +1,201 @@
+# standard library
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+# typing
+from typing import Any, Awaitable, Callable, Dict, Generic, Optional, TypeVar, Union
+
+# third parties
+from aiohttp import ClientResponse, ClientSession
+
+# Youwol utilities
+from youwol.utils.exceptions import raise_exception_from_response
+from youwol.utils.types import JSON
+
+TClientResponse = TypeVar("TClientResponse")
+
+
+class RequestExecutor(ABC, Generic[TClientResponse]):
+    @abstractmethod
+    async def get(
+        self,
+        url: str,
+        default_reader: Callable[[TClientResponse], Awaitable[Any]],
+        custom_reader: Callable[[TClientResponse], Awaitable[Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        pass
+
+    @abstractmethod
+    async def post(
+        self,
+        url: str,
+        default_reader: Callable[[TClientResponse], Awaitable[Any]],
+        custom_reader: Callable[[TClientResponse], Awaitable[Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        pass
+
+    @abstractmethod
+    async def put(
+        self,
+        url: str,
+        default_reader: Callable[[TClientResponse], Awaitable[Any]],
+        custom_reader: Callable[[TClientResponse], Awaitable[Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        pass
+
+    @abstractmethod
+    async def delete(
+        self,
+        url: str,
+        default_reader: Callable[[TClientResponse], Awaitable[Any]],
+        custom_reader: Callable[[TClientResponse], Awaitable[Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        pass
+
+
+@dataclass(frozen=True)
+class AioHttpExecutor(RequestExecutor[ClientResponse]):
+    client_session: Union[ClientSession, Callable[[], ClientSession]]
+    access_token: Callable[[], Awaitable[str]] = None
+
+    @staticmethod
+    def _get_session():
+        return ClientSession(auto_decompress=False)
+
+    async def _trigger_request(
+        self, request: Callable[[ClientSession], Awaitable[Any]]
+    ):
+        if isinstance(self.client_session, ClientSession):
+            return await request(self.client_session)
+
+        async with self.client_session() as session:
+            return await request(session)
+
+    async def _resolve_headers(self, headers: Optional[Dict[str, str]]):
+        static_headers = headers or {}
+        access_token = await self.access_token() if self.access_token else None
+        dynamic_headers = (
+            {"authorization": f"Bearer {access_token}"} if access_token else {}
+        )
+        return {**static_headers, **dynamic_headers}
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        default_reader: Callable[[ClientResponse], Awaitable[Any]],
+        custom_reader: Callable[[ClientResponse], Awaitable[Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        resolved_headers = await self._resolve_headers(headers)
+        kwargs.pop("headers", None)
+        reader = custom_reader or default_reader
+
+        async def request(session: ClientSession):
+            async with await session.request(
+                method=method, url=url, headers=resolved_headers, **kwargs
+            ) as resp:
+                return await reader(resp)
+
+        return await self._trigger_request(request=request)
+
+    async def get(
+        self,
+        url: str,
+        default_reader: Callable[[ClientResponse], Awaitable[Any]],
+        custom_reader: Callable[[ClientResponse], Awaitable[Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        return await self._request(
+            "GET",
+            url=url,
+            default_reader=default_reader,
+            custom_reader=custom_reader,
+            headers=headers,
+            **kwargs,
+        )
+
+    async def post(
+        self,
+        url: str,
+        default_reader: Callable[[ClientResponse], Any],
+        custom_reader: Optional[Callable[[ClientResponse], Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        return await self._request(
+            "POST",
+            url=url,
+            default_reader=default_reader,
+            custom_reader=custom_reader,
+            headers=headers,
+            **kwargs,
+        )
+
+    async def put(
+        self,
+        url: str,
+        default_reader: Callable[[ClientResponse], Any],
+        custom_reader: Optional[Callable[[ClientResponse], Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        return await self._request(
+            "PUT",
+            url=url,
+            default_reader=default_reader,
+            custom_reader=custom_reader,
+            headers=headers,
+            **kwargs,
+        )
+
+    async def delete(
+        self,
+        url: str,
+        default_reader: Callable[[ClientResponse], Any],
+        custom_reader: Optional[Callable[[ClientResponse], Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        return await self._request(
+            "DELETE",
+            url=url,
+            default_reader=default_reader,
+            custom_reader=custom_reader,
+            headers=headers,
+            **kwargs,
+        )
+
+
+async def text_reader(resp: ClientResponse) -> str:
+    if resp.status == 200:
+        resp_text = await resp.text()
+        return resp_text
+
+    await raise_exception_from_response(resp)
+
+
+async def json_reader(resp: ClientResponse) -> JSON:
+    if resp.status == 200:
+        resp_json = await resp.json()
+        return resp_json
+
+    await raise_exception_from_response(resp)
+
+
+async def bytes_reader(resp: ClientResponse) -> bytes:
+    if resp.status == 200:
+        resp_bytes = await resp.read()
+        return resp_bytes
+
+    await raise_exception_from_response(resp)

--- a/src/youwol/utils/clients/stories/stories.py
+++ b/src/youwol/utils/clients/stories/stories.py
@@ -1,118 +1,94 @@
 # standard library
-from dataclasses import dataclass, field
-
-# typing
-from typing import Dict
-
-# third parties
-import aiohttp
+from dataclasses import dataclass
 
 # Youwol utilities
-from youwol.utils.exceptions import raise_exception_from_response
+from youwol.utils.clients.request_executor import (
+    RequestExecutor,
+    bytes_reader,
+    json_reader,
+    text_reader,
+)
 
 
 @dataclass(frozen=True)
 class StoriesClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
-    connector = aiohttp.TCPConnector(verify_ssl=False)
+    request_executor: RequestExecutor
 
     async def healthz(self, **kwargs):
-        url = f"{self.url_base}/healthz"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/healthz",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def docs(self, **kwargs):
-        url = f"{self.url_base}/docs"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/docs",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def create_story(self, body, **kwargs):
-        url = f"{self.url_base}/stories"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.put(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.put(
+            url=f"{self.url_base}/stories",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def publish_story(self, data, **kwargs):
-        url = f"{self.url_base}/stories"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, data=data, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/stories",
+            default_reader=json_reader,
+            data=data,
+            **kwargs,
+        )
 
     async def download_zip(self, story_id: str, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/download-zip"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    return await resp.read()
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/stories/{story_id}/download-zip",
+            default_reader=bytes_reader,
+            **kwargs,
+        )
 
     async def get_story(self, story_id: str, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/stories/{story_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def update_story(self, story_id: str, body, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/stories/{story_id}",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def delete_story(self, story_id: str, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/stories/{story_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_global_contents(self, story_id: str, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/global-contents"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/stories/{story_id}/global-contents",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def post_global_contents(self, story_id: str, body, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/global-contents"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/stories/{story_id}/global-contents",
+            json=body,
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_children(
         self,
@@ -122,104 +98,78 @@ class StoriesClient:
         count=int,
         **kwargs,
     ):
-        params = {"from-index": from_index, "count": count}
-        url = f"{self.url_base}/stories/{story_id}/documents/{parent_document_id}/children"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, params=params, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/stories/{story_id}/documents/{parent_document_id}/children",
+            params={"from-index": from_index, "count": count},
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def get_content(self, story_id: str, content_id: str, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/contents/{content_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/stories/{story_id}/contents/{content_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def set_content(self, story_id: str, content_id: str, body, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/contents/{content_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.text()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/stories/{story_id}/contents/{content_id}",
+            json=body,
+            default_reader=text_reader,
+            **kwargs,
+        )
 
     async def get_document(self, story_id: str, document_id: str, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/documents/{document_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/stories/{story_id}/documents/{document_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def create_document(self, story_id: str, body, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/documents"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.put(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.put(
+            url=f"{self.url_base}/stories/{story_id}/documents",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def delete_document(self, story_id: str, document_id: str, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/documents/{document_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/stories/{story_id}/documents/{document_id}",
+            default_reader=json_reader,
+            **kwargs,
+        )
 
     async def update_document(self, story_id: str, document_id: str, body, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/documents/{document_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/stories/{story_id}/documents/{document_id}",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def move_document(self, story_id: str, document_id: str, body, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/documents/{document_id}/move"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/stories/{story_id}/documents/{document_id}/move",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def add_plugin(self, story_id: str, body, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/plugins"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/stories/{story_id}/plugins",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )
 
     async def upgrade_plugins(self, story_id: str, body, **kwargs):
-        url = f"{self.url_base}/stories/{story_id}/plugins/upgrade"
-
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(url=url, json=body, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/stories/{story_id}/plugins/upgrade",
+            default_reader=json_reader,
+            json=body,
+            **kwargs,
+        )

--- a/src/youwol/utils/clients/treedb/treedb.py
+++ b/src/youwol/utils/clients/treedb/treedb.py
@@ -1,212 +1,168 @@
 # standard library
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 # typing
 from typing import Dict
 
-# third parties
-import aiohttp
-
 # Youwol utilities
-from youwol.utils.exceptions import raise_exception_from_response
+from youwol.utils.clients.request_executor import RequestExecutor, json_reader
 
 
 @dataclass(frozen=True)
 class TreeDbClient:
     url_base: str
 
-    headers: Dict[str, str] = field(default_factory=lambda: {})
-    connector = aiohttp.TCPConnector(verify_ssl=False)
+    request_executor: RequestExecutor
 
     async def healthz(self, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/healthz"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/healthz",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_drives(self, group_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/groups/{group_id}/drives"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/groups/{group_id}/drives",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_drive(self, drive_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/drives/{drive_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/drives/{drive_id}",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_default_drive(self, group_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/groups/{group_id}/default-drive"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/groups/{group_id}/default-drive",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_default_user_drive(self, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/default-drive"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/default-drive",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def create_drive(
         self, group_id: str, body, headers: Dict[str, str], **kwargs
     ):
-        url = f"{self.url_base}/groups/{group_id}/drives"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.put(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.put(
+            url=f"{self.url_base}/groups/{group_id}/drives",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )
 
     async def update_drive(
         self, drive_id: str, body, headers: Dict[str, str], **kwargs
     ):
-        url = f"{self.url_base}/drives/{drive_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    drives = await resp.json()
-                    return drives
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/drives/{drive_id}",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )
 
     async def delete_drive(self, drive_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/drives/{drive_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/drives/{drive_id}",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def create_folder(
         self, parent_folder_id: str, body, headers: Dict[str, str], **kwargs
     ):
-        url = f"{self.url_base}/folders/{parent_folder_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.put(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    folder = await resp.json()
-                    return folder
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.put(
+            url=f"{self.url_base}/folders/{parent_folder_id}",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )
 
     async def update_folder(
         self, folder_id: str, body, headers: Dict[str, str], **kwargs
     ):
-        url = f"{self.url_base}/folders/{folder_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    folder = await resp.json()
-                    return folder
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/folders/{folder_id}",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )
 
     async def move(self, body, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/move"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    folder = await resp.json()
-                    return folder
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/move",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )
 
     async def borrow(self, item_id: str, body, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/items/{item_id}/borrow"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    folder = await resp.json()
-                    return folder
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/items/{item_id}/borrow",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )
 
     async def remove_folder(self, folder_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/folders/{folder_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/folders/{folder_id}",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def remove_item(self, item_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/items/{item_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    resp = await resp.json()
-                    return resp
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/items/{item_id}",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_item(self, item_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/items/{item_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/items/{item_id}",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_path(self, item_id, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/items/{item_id}/path"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/items/{item_id}/path",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_path_folder(self, folder_id, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/folders/{folder_id}/path"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/folders/{folder_id}/path",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_entity(
         self,
@@ -217,108 +173,86 @@ class TreeDbClient:
         include_items: bool = True,
         **kwargs,
     ):
-        url = f"{self.url_base}/entities/{entity_id}"
         params = {
             "include-drives": int(include_drives),
             "include-folders": int(include_folders),
             "include-items": int(include_items),
         }
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(
-                url=url, params=params, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/entities/{entity_id}",
+            default_reader=json_reader,
+            headers=headers,
+            params=params,
+            **kwargs,
+        )
 
     async def get_items_from_asset(
         self, asset_id: str, headers: Dict[str, str], **kwargs
     ):
-        url = f"{self.url_base}/items/from-asset/{asset_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/items/from-asset/{asset_id}",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def update_item(self, item_id: str, body, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/items/{item_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/items/{item_id}",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_folder(self, folder_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/folders/{folder_id}"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/folders/{folder_id}",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_children(self, folder_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/folders/{folder_id}/children"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/folders/{folder_id}/children",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_deleted(self, drive_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/drives/{drive_id}/deleted"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.get(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.get(
+            url=f"{self.url_base}/drives/{drive_id}/deleted",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def purge_drive(self, drive_id: str, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/drives/{drive_id}/purge"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.delete(url=url, headers=headers, **kwargs) as resp:
-                if resp.status == 200:
-                    items = await resp.json()
-                    return items
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.delete(
+            url=f"{self.url_base}/drives/{drive_id}/purge",
+            default_reader=json_reader,
+            headers=headers,
+            **kwargs,
+        )
 
     async def create_item(
         self, folder_id: str, body, headers: Dict[str, str], **kwargs
     ):
-        url = f"{self.url_base}/folders/{folder_id}/items"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.put(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    folder = await resp.json()
-                    return folder
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.put(
+            url=f"{self.url_base}/folders/{folder_id}/items",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )
 
     async def get_records(self, body, headers: Dict[str, str], **kwargs):
-        url = f"{self.url_base}/records"
-        async with aiohttp.ClientSession(headers=self.headers) as session:
-            async with await session.post(
-                url=url, json=body, headers=headers, **kwargs
-            ) as resp:
-                if resp.status == 200:
-                    folder = await resp.json()
-                    return folder
-
-                await raise_exception_from_response(resp, **kwargs)
+        return await self.request_executor.post(
+            url=f"{self.url_base}/records",
+            default_reader=json_reader,
+            json=body,
+            headers=headers,
+            **kwargs,
+        )


### PR DESCRIPTION

*  ♻️ [utils.http-clients] => factorize using `RequestExecutor`
*  👽️ [app] => sync http-clients creation w/ `RequestExecutor`
* 🚚 [app] => move `local_auth.py` in `environment`
* ♻️ [app.`RemoteClients`] => update usage of `RemoteClients`
* ♻️ [app.`upload_asset`] => remote specified by `AssetsGatewayClient`
* ♻️ [pipeline.`PublishCdnRemoteStep`] => simplify w/ new `RemoteClients`
* ♻️ [utils.`RequestExecutor`] => readers applied for status > 300
* ♻️ [utils.http-clients] => simplify using `auto-reader` when possible

TG-1874 #closed