### PR TITLE
TG-1951 py-youwol install & root `__init__.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,12 +95,10 @@ where = [
     "src",
 ]
 include = [
-    "youwol.app*",
-    "youwol.backends*",
-    "youwol.utils*",
-    "youwol.pipelines*",
+    "youwol*",
 ]
 exclude = [
+    "youwol.integrity*",
     "youwol.backends.*.deployment*",
     "youwol.backends.mock*",
     "youwol.backends.common*",


### PR DESCRIPTION
Tested by doing:
` rm -rf ./py-youwol && git clone -b feature/include-root__init__.py https://github.com/youwol/py-youwol.git && pipx uninstall youwol && pipx install ./py-youwol`

resulting site_packages of youwol does include `__init__.py` in addition to the expected modules.

running `youwol` and executing the request:
`http://localhost:2000/admin/system/documentation/youwol`
gives the expected response (including documentation from the root '__init__.py').

TG-1951 #closed