### PR TITLE
TG-2064 error if Redis cache is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 
 ## [0.1.7.post.dev] − Unreleased
 
+### Fixed
+
+-   **Backends**
+    -   Error while retrieving token from `Redis` cache if empty <!-- TG-2064 -->
+
 ## [0.1.7] − 2024-02-08
 
 ### Added

--- a/src/youwol/utils/clients/oidc/tokens_manager.py
+++ b/src/youwol/utils/clients/oidc/tokens_manager.py
@@ -478,7 +478,7 @@ class SessionLessTokenManager:
 
         now = datetime.datetime.now().timestamp()
         token_data = self.__cache.get(self.__cache_key)
-        if not isinstance(token_data, dict):
+        if token_data is not None and not isinstance(token_data, dict):
             raise ValueError(f"Cached value for key {self.__cache_key} is not a `dict`")
         if token_data is None or int(token_data["expires_at"]) < int(now):
             sessionless_tokens_data = await self.__oidc_client.client_credentials_flow()


### PR DESCRIPTION
- 🐛 `tokens_manager` check typing only if not `None`

TG-2064 #closed