### PR TITLE
TG-2030 `routers.prj.models_project` mute pylint E1102

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,6 @@ ignore_missing_imports = true
 
 [tool.pylint]
 disable = [
-    "E1102",
     "W0707",
     "W0719",
     "W0718",

--- a/src/youwol/app/routers/projects/models_project.py
+++ b/src/youwol/app/routers/projects/models_project.py
@@ -323,7 +323,7 @@ class PipelineStep(BaseModel):
         if isinstance(self.sources, FileListing):
             return matching_files(folder=project.path, patterns=self.sources)
         sources_fct = cast(SourcesFct, self.sources)
-        r = sources_fct(self, project, flow_id, context)
+        r = sources_fct(self, project, flow_id, context)  # pylint: disable=not-callable
         r = await r if isinstance(r, Awaitable) else r
         return (
             matching_files(folder=project.path, patterns=r)


### PR DESCRIPTION
- 🚨 `routers.prj.models_project` mute pylint E1102

TG-2030 #closed