### PR TITLE
TG-2147 [doc] => improve code snippet display.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
   - sync. documentation version with `youwol` version. <!-- TG 2131 -->
   - serve documentation from `/doc`. <!-- TG 2130 -->
   - module's symbols grouped by file. <!-- TG 2143, TG-2146 -->
+  - improved code snippets display. <!-- TG-2147 -->
 - **Experimental**
   - Configuration dependant browser caching (disabled by default) <!-- TG-2126 -->
   

--- a/doc/src/app/py-doc/code.view.ts
+++ b/doc/src/app/py-doc/code.view.ts
@@ -1,6 +1,6 @@
 import { ChildrenLike, VirtualDOM } from '@youwol/rx-vdom'
 import { BehaviorSubject } from 'rxjs'
-import { Router, parseMd } from '@youwol/mkdocs-ts'
+import { parseMd, Router } from '@youwol/mkdocs-ts'
 import { Routers } from '@youwol/local-youwol-client'
 import { Configuration } from './index'
 
@@ -69,7 +69,7 @@ export class PyCodeView implements VirtualDOM<'div'> {
     public readonly tag = 'div'
     public readonly class = 'fv-border-primary rounded'
     public readonly style = {
-        fontSize: '0.8rem',
+        fontSize: '0.9rem',
     }
     public readonly children: ChildrenLike
     public readonly expanded$ = new BehaviorSubject(false)
@@ -96,10 +96,7 @@ export class PyCodeView implements VirtualDOM<'div'> {
                         class: 'ml-1 mr-1 mt-1',
                         children: [
                             parseMd({
-                                src:
-                                    '```python\n' +
-                                    removeDocString(this.codeDoc.content) +
-                                    '\n```\n',
+                                src: `<code-snippet language="python">${this.codeDoc.content}</code-snippet>`,
                                 router: this.router,
                             }),
                         ],
@@ -108,8 +105,4 @@ export class PyCodeView implements VirtualDOM<'div'> {
             },
         ]
     }
-}
-
-function removeDocString(code: string) {
-    return code.replace(/"""[\s\S]*?"""\n/g, '"""').replace(/"""/g, '')
 }

--- a/src/youwol/app/environment/__init__.py
+++ b/src/youwol/app/environment/__init__.py
@@ -9,10 +9,10 @@ run-time.
 Note:
     The current environment is available each time an instance of [Context](@yw-nav-class:Context)
     is, using:
-    ```python
+    <code-snippet language="python">
     ctx: Context # some instance of Context
     yw_env = await ctx.get('env', YouwolEnvironment)
-    ```
+    </code-snippet>
 """
 
 # relative

--- a/src/youwol/app/environment/config_from_module.py
+++ b/src/youwol/app/environment/config_from_module.py
@@ -47,15 +47,14 @@ class IConfigurationFactory(ABC):
     object as last statement of the python configuration file.
 
     Example:
-
-        ```python
+        <code-snippet language="python">
         from youwol.app.environment import Configuration, IConfigurationFactory
         from youwol.app.main_args import MainArguments
 
         class ConfigurationFactory(IConfigurationFactory):
             async def get(self, main_args: MainArguments) -> Configuration:
                 return Configuration()
-        ```
+        </code-snippet>
 
         Derived class should implement the **get** method.
     """

--- a/src/youwol/app/environment/models/flow_switches.py
+++ b/src/youwol/app/environment/models/flow_switches.py
@@ -114,7 +114,7 @@ class FlowSwitcherMiddleware(CustomMiddleware):
      element match against the original request.
 
      Example:
-        ```python hl_lines="5-7 9-16 22-29"
+        <code-snippet language="python" highlightedLines="5-7 9-16 22-29">
         from youwol.app.environment import (
             Configuration,
             Customization,
@@ -147,7 +147,7 @@ class FlowSwitcherMiddleware(CustomMiddleware):
                 ],
             )
         )
-        ```
+        </code-snippet>
         In the above snippet to FlowSwitcherMiddleware middleware are added:
 
         *  the first one ([CdnSwitch](@yw-nav-class:CdnSwitch))
@@ -218,7 +218,7 @@ class CdnSwitch(FlowSwitch):
         Below is a typical example of usage of CdnSwitch within a
         [FlowSwitcherMiddleware](@yw-nav-class:FlowSwitcherMiddleware):
 
-        ```python hl_lines="5 14"
+        <code-snippet language="python" highlightedLines="5 14">
         from youwol.app.environment import (
             Configuration,
             Customization,
@@ -237,7 +237,7 @@ class CdnSwitch(FlowSwitch):
                 ],
             )
         )
-        ```
+        </code-snippet>
         Each time a resource from `@youwol/foo-app` is queried, it will be redirected to `localhost:4001`.
     """
 
@@ -337,7 +337,7 @@ class RedirectSwitch(FlowSwitch):
         Below is a typical example of usage of RedirectSwitch within a
         [FlowSwitcherMiddleware](@yw-nav-class:FlowSwitcherMiddleware):
 
-        ```python hl_lines="5 8-11 18"
+        <code-snippet language="python" highlightedLines="5 8-11 18">
         from youwol.app.environment import (
             Configuration,
             Customization,
@@ -360,7 +360,7 @@ class RedirectSwitch(FlowSwitch):
                 ],
             )
         )
-        ```
+        </code-snippet>
         Each time a request to `/api/foo-backend/**` is intercepted, it will be redirected to `localhost:4002`.
     """
 

--- a/src/youwol/app/environment/models/model_remote.py
+++ b/src/youwol/app/environment/models/model_remote.py
@@ -82,7 +82,7 @@ class CloudEnvironment(BaseModel):
     Example:
         The standard youwol cloud environment connected using a browser connection or a direct connection:
 
-        ```python
+        <code-snippet language="python">
         from pathlib import Path
 
         from youwol.app.environment import (
@@ -104,7 +104,7 @@ class CloudEnvironment(BaseModel):
                 DirectAuth(authId="bar", userName="bar", password="bar-pwd"),
             ],
         )
-        ```
+        </code-snippet>
     """
 
     envId: str
@@ -159,7 +159,7 @@ class CloudEnvironments(BaseModel):
     Example:
         Below is an example declaring 2 cloud environments, one related to a hypothetical remote environment of
         a company `foo`, and the second the regular youwol remote environment :
-        ```python
+        <code-snippet language="python">
 
         from pathlib import Path
 
@@ -199,7 +199,7 @@ class CloudEnvironments(BaseModel):
                 )
             )
         )
-        ```
+        <code-snippet>
     """
 
     defaultConnection: Connection
@@ -222,7 +222,7 @@ class LocalEnvironment(BaseModel):
     If paths are relatives, they are referenced with respect to the parent folder of the configuration file.
 
     Example:
-        ```python
+        <code-snippet language="python">
         from pathlib import Path
 
         from youwol.app.environment import (
@@ -239,7 +239,7 @@ class LocalEnvironment(BaseModel):
                 )
             )
         )
-        ```
+        </code-snippet>
 
     """
 

--- a/src/youwol/app/environment/models/models_config.py
+++ b/src/youwol/app/environment/models/models_config.py
@@ -82,7 +82,7 @@ class LocalEnvironment(BaseModel):
     If paths are relatives, they are referenced with respect to the parent folder of the configuration file.
 
     Example:
-        ```python
+        <code-snippet language='python'>
         from pathlib import Path
 
         from youwol.app.environment import (
@@ -99,8 +99,7 @@ class LocalEnvironment(BaseModel):
                 )
             )
         )
-        ```
-
+        </code-snippet>
     """
 
     dataDir: ConfigPath = default_path_data_dir
@@ -127,7 +126,7 @@ class System(BaseModel):
 
     The default value is most of the time adapted for most users:
 
-    ```python hl_lines="5 9"
+    <code-snippet language="python" highlightedLines="5 9">
     from pathlib import Path
 
     from youwol.app.environment import (
@@ -138,7 +137,7 @@ class System(BaseModel):
     Configuration(
         system=System()
     )
-    ```
+    </code-snippet>
     In a nutshell:
 
     *  it defines the serving http port to `2000`
@@ -148,7 +147,7 @@ class System(BaseModel):
     (see [LocalEnvironment](@yw-nav-class:models_config.LocalEnvironment))
 
     The above example is equivalent to:
-    ```python
+    <code-snippet language="python">
     from pathlib import Path
 
     from youwol.app.environment import (
@@ -185,7 +184,7 @@ class System(BaseModel):
             localEnvironment=LocalEnvironment()
         )
     )
-    ```
+    </code-snippet>
     """
 
     httpPort: int | None = default_http_port
@@ -234,7 +233,7 @@ class Command(BaseModel):
     `/admin/custom-commands/$NAME`, where `$NAME` is the name of the command.
 
     Example:
-        ```python hl_lines="4 12-19"
+        <code-snippet language="python" highlightedLines="4 12-19">
         from youwol.app.environment import (
             Configuration,
             Customization,
@@ -258,7 +257,7 @@ class Command(BaseModel):
                 )
             )
         )
-        ```
+        </code-snippet>
         In the above example, two commands (one `GET` and one `POST`) are defined,
          both exposed from `/admin/custom-commands/example`.
     """
@@ -314,7 +313,7 @@ class CustomMiddleware(BaseModel, ABC):
 
     Example:
         Below is a typical example
-        ```python
+        <code-snippet language="python">
         from starlette.middleware.base import RequestResponseEndpoint
         from starlette.requests import Request
         from youwol.app.environment import (
@@ -334,7 +333,7 @@ class CustomMiddleware(BaseModel, ABC):
                 ) as ctx:
                     await ctx.info("Hello")
                     return await call_next(incoming_request)
-        ```
+        </code-snippet>
     """
 
     async def dispatch(
@@ -368,7 +367,7 @@ class Customization(BaseModel):
     Example:
         Below is an example spanning most of the attribute of the class:
 
-        ```python
+        <code-snippet language="python">
         from youwol.app.environment import (
             Configuration,
             Customization,
@@ -415,7 +414,7 @@ class Customization(BaseModel):
                 )
             )
         )
-        ```
+        </code-snippet>
 
         In a nutshell:
 
@@ -447,16 +446,14 @@ class Configuration(BaseModel):
 
     Every parameter is optional, to provide the default configuration:
 
-    ```python
-
+    <code-snippet language="python">
     from youwol.app.environment import Configuration
 
     Configuration()
-    ```
+    </code-snippet>
 
     Which is equivalent to:
-    ```python
-
+    <code-snippet language="python">
     from youwol.app.environment import Configuration, System, Projects, Customization
 
     Configuration(
@@ -464,7 +461,7 @@ class Configuration(BaseModel):
         projects=Projects(),
         customization=Customization()
     )
-    ```
+    </code-snippet>
     """
 
     system: System = System()

--- a/src/youwol/app/environment/models/models_project.py
+++ b/src/youwol/app/environment/models/models_project.py
@@ -40,7 +40,7 @@ class ProjectTemplate(BaseModel):
     In most practical cases, project template generator are exposed by python packages and consumed in the configuration
     file, for instance regarding the typescript pipeline of youwol:
 
-    ```python hl_lines="5 11"
+    <code-snippet language="python" highlightedLines="5 11">
     from youwol.app.environment import (
         Configuration,
         Projects,
@@ -54,7 +54,7 @@ class ProjectTemplate(BaseModel):
             templates=[app_ts_webpack_template(folder=projects_folder)],
         )
     )
-    ```
+    </code-snippet>
 
     """
 
@@ -115,7 +115,7 @@ class RecursiveProjectsFinder(ProjectsFinder):
     Strategy to discover all projects below the provided paths with optional continuous watching.
 
     Example:
-        ```python hl_lines="6 13-17"
+        <code-snippet language="python" highlightedLines="6 13-17">
         from pathlib import Path
 
         from youwol.app.environment import (
@@ -135,7 +135,7 @@ class RecursiveProjectsFinder(ProjectsFinder):
                 )
             )
         )
-        ```
+        </code-snippet>
 
     **Troubleshooting**
 
@@ -217,7 +217,7 @@ class ExplicitProjectsFinder(ProjectsFinder):
      class allows such features.
 
      Example:
-        ```python hl_lines="6 13-15"
+        <code-snippet language="python" highlightedLines="6 13-15">
         from pathlib import Path
 
         from youwol.app.environment import (
@@ -235,7 +235,7 @@ class ExplicitProjectsFinder(ProjectsFinder):
                 )
             )
         )
-        ```
+        </code-snippet>
 
     """
 
@@ -267,7 +267,7 @@ class Projects(BaseModel):
     Example:
         A typical example of this section of the configuration looks like:
 
-        ```python hl_lines="5 6 8 13 14 15 16 17 18"
+        <code-snippet language="python" highlightedLines="5 6 8 13 14 15 16 17 18">
         from pathlib import Path
 
         from youwol.app.environment import (
@@ -287,7 +287,7 @@ class Projects(BaseModel):
                 templates=[app_ts_webpack_template(folder=projects_folder)],
             )
         )
-        ```
+        </code-snippet>
     """
 
     finder: ProjectsFinder | ConfigPath = RecursiveProjectsFinder()

--- a/src/youwol/app/routers/projects/models_project.py
+++ b/src/youwol/app/routers/projects/models_project.py
@@ -450,9 +450,9 @@ class Flow(BaseModel):
 
     **Example**
 
-    ```python
+    <code-snippet language="python">
     flow = Flow(name='flow', steps=['init > build > publish', 'init > doc > publish'])
-    ```
+    </code-snippet>
     Where `init`, `build`, `doc`, `publish` refers to ID of steps included in the
      [Pipeline](@yw-nav-class:youwol.app.routers.projects.models_project.Pipeline).
     """


### PR DESCRIPTION
*  ♻️ [py-doc] => `PyCodeView` uses `<code-snippet>` to improve snippets
*  📝 Docstrings uses `<code-snippet>` instead native MD syntax
*  📝 update `CHANGELOG.md`

TG-2147 #closed