### PR TITLE
TG-2175 Missing CDN status event @ publish local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 
 - Sync. typescript pipeline's `template.py` generator with youwol API updates. <!-- TG-2167 -->
 - python backend pipeline: ensure python scripts execution has correct environment variable `PYTHONPATH` <!-- TG-2168 -->
+- Emit 'components update' signal when publishing a project in local database. <!-- TG-2175 -->
 
 <!-- Not worthy of inclusion
 TG-2169

--- a/src/youwol/pipelines/publish_cdn.py
+++ b/src/youwol/pipelines/publish_cdn.py
@@ -26,6 +26,7 @@ from youwol.app.environment import (
 from youwol.app.routers.environment.upload_assets.package import UploadPackageOptions
 from youwol.app.routers.environment.upload_assets.upload import upload_asset
 from youwol.app.routers.local_cdn import download_package
+from youwol.app.routers.local_cdn.router import emit_local_cdn_status
 from youwol.app.routers.projects.models_project import (
     BrowserApp,
     ExplicitNone,
@@ -338,6 +339,7 @@ class PublishCdnLocalStep(PipelineStep):
             resp["asset"] = asset
             resp["access"] = access
             resp["explorerItem"] = explorer_item
+            await emit_local_cdn_status(context=ctx)
             return resp
 
     @staticmethod


### PR DESCRIPTION
*  🚑️ [pipelines] => send CDN status update after publication in local DB.
*  📝 update `CHANGELOG.md`

TG-2175 #closed