### PR TITLE
TG-2183 adapt 'login' end-point & EnvStatus API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 
 ## [0.1.9.dev] − Unreleased
 
+### Changed
+
+- Sanitize `EnvironmentStatusResponse` API from `admin/environment/status` endpoint. <!-- TG-2183 -->
+
 ### Fixed
 
 - Prevent digest infinite recursion and handle more types <!-- TG-2166 -->
+- Fix wrong evaluation order of JWT providers in `AuthMiddleware`. <!-- TG-2194 -->
 
 ## [0.1.8.dev] − Unreleased
 

--- a/src/youwol/app/environment/models/tokens_storage/path_base.py
+++ b/src/youwol/app/environment/models/tokens_storage/path_base.py
@@ -154,7 +154,7 @@ class TokensStoragePathBase(TokensStorage, ABC):
             "session_ids": self.__session_ids,
         }
         with self._get_path_like().open_w() as fp:
-            json.dump(data, fp)
+            json.dump(data, fp, indent=4)
 
     async def __reset(self) -> None:
         await self._reset()

--- a/src/youwol/app/fastapi_app.py
+++ b/src/youwol/app/fastapi_app.py
@@ -167,6 +167,7 @@ def setup_middlewares(env: YouwolEnvironment):
         ),
         jwt_providers=[
             JwtProviderBearerDynamicIssuer(),
+            JwtProviderPyYouwol(),
             JwtProviderCookieDynamicIssuer(
                 tokens_manager=TokensManager(
                     storage=env.tokens_storage,
@@ -175,7 +176,6 @@ def setup_middlewares(env: YouwolEnvironment):
                     ).for_client(env.get_remote_info().authProvider.openidClient),
                 ),
             ),
-            JwtProviderPyYouwol(),
         ],
         on_missing_token=lambda url, text: (
             redirect_to_login(url)
@@ -234,6 +234,13 @@ def setup_http_routers():
         return RedirectResponse(
             status_code=308,
             url=f"/applications/@youwol/py-youwol-doc/{yw_doc_version()}",
+        )
+
+    @fastapi_app.get(api_configuration.base_path + "/co-lab")
+    async def colab():
+        return RedirectResponse(
+            status_code=308,
+            url="/applications/@youwol/co-lab/^0.1.5",
         )
 
 

--- a/src/youwol/app/routers/backends/implementation.py
+++ b/src/youwol/app/routers/backends/implementation.py
@@ -21,7 +21,7 @@ from starlette.requests import Request
 # Youwol application
 from youwol.app.environment import YouwolEnvironment
 from youwol.app.environment.proxied_backends import ProxiedBackend
-from youwol.app.routers.environment.router import get_status_impl
+from youwol.app.routers.environment.router import emit_environment_status
 from youwol.app.routers.local_cdn.router import package_info
 from youwol.app.web_socket import LogsStreamer
 
@@ -284,7 +284,7 @@ async def ensure_running(
                 install_outputs=install_outputs,
                 server_outputs_ctx_id=std_outputs_ctx_id,
             )
-            await get_status_impl(request=request, context=ctx)
+            await emit_environment_status(context=ctx)
             return proxy
         except TimeoutError:
             process.terminate()

--- a/src/youwol/app/routers/environment/models.py
+++ b/src/youwol/app/routers/environment/models.py
@@ -1,6 +1,9 @@
 # standard library
 from enum import Enum
 
+# typing
+from typing import Literal
+
 # third parties
 from pydantic import BaseModel
 
@@ -35,9 +38,39 @@ class CustomDispatchesResponse(BaseModel):
     dispatches: dict[str, list[DispatchInfo]]
 
 
-class RemoteGatewayInfo(BaseModel):
+class AuthenticationResponse(BaseModel):
+    """
+    Response model corresponding to [Authentication](@yw-nav-class:model_remote.Authentication).
+    """
+
+    authId: str
+    """
+    Authentication's ID.
+    """
+    type: Literal["BrowserAuth", "DirectAuth"]
+    """
+    Authentication's type.
+    """
+
+
+class CloudEnvironmentResponse(BaseModel):
+    """
+    Response model corresponding to [CloudEnvironment](@yw-nav-class:CloudEnvironment).
+    """
+
+    envId: str
+    """
+    Environment Id, see [CloudEnvironment.envId](@yw-nav-attr:CloudEnvironment.envId).
+    """
     host: str
-    connected: bool | None
+    """
+    Host, see [CloudEnvironment.host](@yw-nav-attr:CloudEnvironment.host).
+    """
+    authentications: list[AuthenticationResponse]
+    """
+    Available authentication modes, see
+    [CloudEnvironment.authentications](@yw-nav-attr:CloudEnvironment.authentications).
+    """
 
 
 class SwitchConfigurationBody(BaseModel):

--- a/src/youwol/app/routers/system/router.py
+++ b/src/youwol/app/routers/system/router.py
@@ -21,7 +21,7 @@ from starlette.requests import Request
 # Youwol application
 from youwol.app.environment import YouwolEnvironment, yw_config
 from youwol.app.routers.backends.implementation import INSTALL_MANIFEST_FILE
-from youwol.app.routers.environment.router import get_status_impl
+from youwol.app.routers.environment.router import emit_environment_status
 from youwol.app.routers.system.documentation import (
     YOUWOL_MODULE,
     check_documentation,
@@ -361,7 +361,7 @@ async def terminate(
             await env.proxied_backends.terminate(
                 name=name, version=version, context=ctx
             )
-            await get_status_impl(request=request, context=ctx)
+            await emit_environment_status(context=ctx)
 
         return TerminateResponse(
             name=name, version=version, wasRunning=proxied is not None
@@ -398,7 +398,7 @@ async def uninstall(
             await env.proxied_backends.terminate(
                 name=name, version=version, context=ctx
             )
-            await get_status_impl(request=request, context=ctx)
+            await emit_environment_status(context=ctx)
 
         manifest = (
             env.pathsBook.local_cdn_component(name=name, version=version)

--- a/src/youwol/pipelines/pipeline_python_backend/pipeline.py
+++ b/src/youwol/pipelines/pipeline_python_backend/pipeline.py
@@ -14,7 +14,7 @@ from youwol.utils.python_next.v3_12 import tomllib
 
 # Youwol application
 from youwol.app.environment import YouwolEnvironment
-from youwol.app.routers.environment.router import get_status_impl
+from youwol.app.routers.environment.router import emit_environment_status
 from youwol.app.routers.projects import (
     Artifact,
     CommandPipelineStep,
@@ -318,7 +318,7 @@ class RunStep(PipelineStep):
                         install_outputs=["Backend running from sources."],
                         server_outputs_ctx_id=shell_ctx.uid,
                     )
-                    await get_status_impl(request=ctx.request, context=shell_ctx)
+                    await emit_environment_status(context=shell_ctx)
                     await shell_ctx.info(
                         text=f"Dispatch installed from '/backends/{project.name}/{project.version}' "
                         f"to 'localhost:{port}"


### PR DESCRIPTION
*  🎨 [env.models] => prettier persisted `TokensStoragePathBase`
*  ♻️ [app.routers.env] => clean `EnvironmentStatusResponse`
*  🐛 [fastapi_app] => JWT prov. `PyYouwol` before `CookieDynamicIssuer`
*  🥅 [app.routers.env] => `login` handle `NeedInteractiveSession`
*  📝 update `CHANGELOG.md`

TG-2183 #closed