### PR TITLE
TG-2196 projects failure due to pipelinesNotFound are not handled properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 
 - Prevent digest infinite recursion and handle more types <!-- TG-2166 -->
 - Fix wrong evaluation order of JWT providers in `AuthMiddleware`. <!-- TG-2194 -->
+- Discriminates `FailurePipelineNotFound` from `FailureImportException`. <!-- TG-2196 -->
 
 ## [0.1.8.dev] − Unreleased
 

--- a/src/youwol/app/routers/projects/models.py
+++ b/src/youwol/app/routers/projects/models.py
@@ -17,9 +17,22 @@ PipelineStepId = str
 
 
 class Failure(BaseModel):
+    """
+    Base class of project loading failures.
+    """
+
     path: Path
+    """
+    Project folder's path.
+    """
     failure: str = "generic"
+    """
+    Failure type.
+    """
     message: str
+    """
+    Message.
+    """
 
 
 class FailurePipelineNotFound(Failure):
@@ -28,7 +41,13 @@ class FailurePipelineNotFound(Failure):
     """
 
     failure: str = "pipeline_not_found"
-    message: str = "Pipeline not found"
+    """
+    Failure type.
+    """
+    message: str = "Pipeline `.yw_pipeline/yw_pipeline.py` not found"
+    """
+    Message.
+    """
 
 
 class FailureDirectoryNotFound(Failure):
@@ -37,7 +56,13 @@ class FailureDirectoryNotFound(Failure):
     """
 
     failure: str = "directory_not_found"
+    """
+    Failure type.
+    """
     message: str = "Project's directory not found"
+    """
+    Message.
+    """
 
 
 class FailureImportException(Failure):
@@ -46,8 +71,17 @@ class FailureImportException(Failure):
     """
 
     failure: str = "import"
+    """
+    Failure type.
+    """
     traceback: str
+    """
+    Traceback of the exception.
+    """
     exceptionType: str
+    """
+    Exception type.
+    """
 
 
 class ListProjectsResponse(BaseModel):

--- a/src/youwol/app/routers/projects/projects_loader.py
+++ b/src/youwol/app/routers/projects/projects_loader.py
@@ -177,6 +177,24 @@ async def get_project(
     env: YouwolEnvironment,
     context: Context,
 ) -> Project | Failure:
+    """
+    Retrieves project information and pipeline definition from the specified project directory.
+
+    This function reads the project directory at the given `project_path`, validates its structure, and attempts
+    to import the pipeline definition file. Upon successful import, it constructs a Project object representing
+    the project, including its pipeline instance.
+
+    Parameters:
+        project_path: The path to the project directory.
+        additional_python_src_paths: Additional paths to search for Python source files required
+            for importing the pipeline definition.
+        env: The current youwol environment.
+        context: The current context.
+
+    Return:
+        An instance of the Project class representing the retrieved project information,
+        or a Failure object indicating any encountered errors during the retrieval process.
+    """
     async with context.start(
         action="get_project", with_attributes={"folderName": project_path.name}
     ) as ctx:

--- a/src/youwol/app/routers/projects/projects_loader.py
+++ b/src/youwol/app/routers/projects/projects_loader.py
@@ -187,6 +187,12 @@ async def get_project(
             return error
 
         pipeline_path = project_path / PROJECT_PIPELINE_DIRECTORY / "yw_pipeline.py"
+        if not pipeline_path.exists():
+            error = FailurePipelineNotFound(path=project_path)
+            message = f"Can not find pipeline's definition file '{pipeline_path}'."
+            await ctx.error(text=message, data=error)
+            log_error(message, {"path": str(project_path)})
+            return error
 
         async def handle_import_error(import_error: FailureImportException):
             import_error_message = "Failed to import project"


### PR DESCRIPTION
🐛 [app.routers.projects] => handle `FailurePipelineNotFound`
📝 [app.routers.projects] => add documentation

TG-2196 #closed