### PR TITLE
Bug/misc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 -  The `dev. portal` link proposed in the terminal at startup has been removed . <!-- TG-2233 -->
 
 <!-- Not worthy of inclusion
+TG-2262 : 🐛 [app] fix backends install can be executed twice
 TG-2260 : 🐛 [app] missing update signals from web sockets
 TG-2261 : 🐛 [app] missing actual method call in `file_path.exists`
 TG-2255 : 🐛 [pipeline.py_backend] => fix missing WS status update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 -  The `dev. portal` link proposed in the terminal at startup has been removed . <!-- TG-2233 -->
 
 <!-- Not worthy of inclusion
+TG-2261 : 🐛 [app] missing actual method call in `file_path.exists`
 TG-2255 : 🐛 [pipeline.py_backend] => fix missing WS status update
 TG-2252 : 🐛 [app] set `no-cache` for downloaded components.
 TG-2251 : ♻️ [app] : simplify AssetDownloadThread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
   -  explicit local installation on `admin/system/backends/install` using CDN's loading graph response. <!-- TG-2205 -->
 - **Pyodide components**:
   -  intercept Pyodide resources requests to store them within the local CDN database. <!-- TG-2238 -->
-  
+- **Pipelines**:
+  -  configured by default to publish in connected remote and public NPM (if applicable). <!-- TG-2254 --> 
+
 ### Changed
 
 - **Breaking:** Refactor the `ProjectsFinder` API and its associated implementation to improve performance and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 -  The `dev. portal` link proposed in the terminal at startup has been removed . <!-- TG-2233 -->
 
 <!-- Not worthy of inclusion
+TG-2255 : 🐛 [pipeline.py_backend] => fix missing WS status update
 TG-2252 : 🐛 [app] set `no-cache` for downloaded components.
 TG-2251 : ♻️ [app] : simplify AssetDownloadThread
 TG-2230 : ⚰️ [app.env] => remove `py_youwol_tour` configs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 -  The `dev. portal` link proposed in the terminal at startup has been removed . <!-- TG-2233 -->
 
 <!-- Not worthy of inclusion
+TG-2265 : 🐛 [pipeline.py_backend] fix self-contained venvs.
 TG-2264 : 🐛 [pipeline.py_backend] fix wrong path from `generate_template`
 TG-2263 : 🐛 [app.projects] fix duplicate issue in projects list response
 TG-2262 : 🐛 [app] fix backends install can be executed twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 -  The `dev. portal` link proposed in the terminal at startup has been removed . <!-- TG-2233 -->
 
 <!-- Not worthy of inclusion
+TG-2263 : 🐛 [app.projects] fix duplicate issue in projects list response
 TG-2262 : 🐛 [app] fix backends install can be executed twice
 TG-2260 : 🐛 [app] missing update signals from web sockets
 TG-2261 : 🐛 [app] missing actual method call in `file_path.exists`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 -  The `dev. portal` link proposed in the terminal at startup has been removed . <!-- TG-2233 -->
 
 <!-- Not worthy of inclusion
+TG-2264 : 🐛 [pipeline.py_backend] fix wrong path from `generate_template`
 TG-2263 : 🐛 [app.projects] fix duplicate issue in projects list response
 TG-2262 : 🐛 [app] fix backends install can be executed twice
 TG-2260 : 🐛 [app] missing update signals from web sockets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 -  The `dev. portal` link proposed in the terminal at startup has been removed . <!-- TG-2233 -->
 
 <!-- Not worthy of inclusion
+TG-2260 : 🐛 [app] missing update signals from web sockets
 TG-2261 : 🐛 [app] missing actual method call in `file_path.exists`
 TG-2255 : 🐛 [pipeline.py_backend] => fix missing WS status update
 TG-2252 : 🐛 [app] set `no-cache` for downloaded components.

--- a/integrations/yw_config.py
+++ b/integrations/yw_config.py
@@ -62,8 +62,10 @@ from youwol.utils.http_clients.cdn_backend.utils import (
 )
 
 # Youwol pipelines
-import youwol.pipelines.pipeline_typescript_weback_npm as pipeline_ts
+import youwol.pipelines.pipeline_python_backend as pipeline_py_backend
+import youwol.pipelines.pipeline_raw_app as pipeline_raw
 
+from youwol.pipelines import Environment
 from youwol.pipelines.pipeline_typescript_weback_npm import (
     app_ts_webpack_template,
     lib_ts_webpack_template,
@@ -278,7 +280,7 @@ async def erase_all_test_data_remote(context: Context):
         return {"items": resp["items"]}
 
 
-pipeline_ts.set_environment()
+pipeline_raw.set_environment(Environment(cdnTargets=[]))
 
 
 def apply_test_labels_logs(body, _ctx):
@@ -393,6 +395,7 @@ class ConfigurationFactory(IConfigurationFactory):
                 templates=[
                     lib_ts_webpack_template(folder=projects_folder),
                     app_ts_webpack_template(folder=projects_folder),
+                    pipeline_py_backend.template(folder=projects_folder),
                 ],
             ),
             customization=Customization(

--- a/src/youwol/app/environment/browser_cache_store.py
+++ b/src/youwol/app/environment/browser_cache_store.py
@@ -199,7 +199,7 @@ class BrowserCacheStore:
 
         item = self._items[key]
         file_path = Path(item.file)
-        if not file_path.exists:
+        if not file_path.exists():
             self._items.pop(key)
             return
 

--- a/src/youwol/app/routers/backends/implementation.py
+++ b/src/youwol/app/routers/backends/implementation.py
@@ -168,10 +168,6 @@ async def install_backend_shell(
         cmd_install = f"(cd {folder} &&  sh ./install.sh)"
 
         return_code, outputs = await execute_shell_cmd(cmd=cmd_install, context=ctx)
-        if return_code > 0:
-            (folder / INSTALL_MANIFEST_FILE).write_text(
-                functools.reduce(lambda acc, e: acc + e, outputs, "")
-            )
         if return_code > 1:
             await ctx.send(
                 InstallBackendEvent(
@@ -181,6 +177,9 @@ async def install_backend_shell(
             raise InstallBackendFailed(
                 return_code=return_code, outputs=outputs, ctx_id=context.uid
             )
+        (folder / INSTALL_MANIFEST_FILE).write_text(
+            functools.reduce(lambda acc, e: acc + e, outputs, "")
+        )
 
         await ctx.send(
             InstallBackendEvent(
@@ -285,7 +284,7 @@ async def ensure_running(
         if not matching_versions:
             raise HTTPException(
                 status_code=404,
-                detail=f"No matching version fo  '{backend_name}' match selector ${version_query}",
+                detail=f"No matching version for '{backend_name}' match selector {version_query}",
             )
 
         latest_version_backend = sorted(matching_versions, key=Version, reverse=True)[0]
@@ -300,9 +299,6 @@ async def ensure_running(
                 name=backend_name,
                 version=latest_version_backend,
                 context=ctx,
-            )
-            (folder / INSTALL_MANIFEST_FILE).write_text(
-                functools.reduce(lambda acc, e: acc + e, install_outputs, "")
             )
         else:
             install_outputs = [f"Backend {backend_name} already installed"]
@@ -428,7 +424,7 @@ async def download_install_backend(
                 )
             )
         folder = env.pathsBook.local_cdn_component(name=backend_name, version=version)
-        if not (folder / ".venv").exists():
+        if not (folder / INSTALL_MANIFEST_FILE).exists():
             await install_backend_shell(
                 folder=folder, name=backend_name, version=version, context=ctx
             )

--- a/src/youwol/app/routers/projects/implementation.py
+++ b/src/youwol/app/routers/projects/implementation.py
@@ -34,6 +34,13 @@ from .models_project import (
     Project,
 )
 from .projects_resolver import ProjectLoader
+from .projects_resolver.projects_loader import ProjectsLoadingResults
+
+
+async def emit_projects_status(context: Context) -> ProjectsLoadingResults:
+    response = ProjectLoader.status()
+    await context.send(response)
+    return response
 
 
 def is_step_running(

--- a/src/youwol/app/routers/projects/projects_resolver/projects_loader.py
+++ b/src/youwol/app/routers/projects/projects_resolver/projects_loader.py
@@ -112,6 +112,9 @@ class ProjectLoader:
         """
         Retrieves the current loading status including projects and failures.
         """
+        ProjectLoader.projects_list = list(
+            {p.path: p for p in ProjectLoader.projects_list}.values()
+        )
         return ProjectsLoadingResults(
             results=ProjectLoader.projects_list, failures=ProjectLoader.failures_report
         )

--- a/src/youwol/app/routers/projects/router.py
+++ b/src/youwol/app/routers/projects/router.py
@@ -679,6 +679,11 @@ async def new_project_from_template(
         await ctx.info(text="Found template generator", data=template)
         _, path = await template.generator(template.folder, body.parameters, ctx)
 
+        project = next((p for p in ProjectLoader.projects_list if p.path == path), None)
+        if project:
+            # The projects finder already got the project creation (watch is True)
+            return project
+
         response = await ProjectLoader.refresh(ctx)
         await ctx.send(response)
 

--- a/src/youwol/app/routers/projects/router.py
+++ b/src/youwol/app/routers/projects/router.py
@@ -30,6 +30,7 @@ from youwol.utils.utils_paths import parse_json, write_json
 from .dependencies import resolve_project_dependencies
 from .implementation import (
     create_artifacts,
+    emit_projects_status,
     format_artifact_response,
     get_project_configuration,
     get_project_flow_steps,
@@ -84,9 +85,7 @@ async def status(request: Request) -> ProjectsLoadingResults:
     async with Context.start_ep(
         request=request, with_reporters=[LogsStreamer()]
     ) as ctx:
-        response = ProjectLoader.status()
-        await ctx.send(response)
-        return response
+        return await emit_projects_status(context=ctx)
 
 
 @router.post(

--- a/src/youwol/app/routers/python/router.py
+++ b/src/youwol/app/routers/python/router.py
@@ -294,6 +294,7 @@ async def try_local(info: ResourceInfo, context: Context) -> Response | None:
             headers=context.headers(),
             custom_reader=aiohttp_to_starlette_response,
         )
+        # This header will most likely be mutated by `BrowserCacheStore` as CDN resources are cached in usual scenarios.
         resp.headers.append("youwol-origin", "local")
         return resp
     except HTTPException as e:
@@ -357,6 +358,7 @@ async def get_and_persist_resource(
                 url=target_url, headers=headers
             ) as resp_head:
                 headers_resp = dict(resp_head.headers.items())
+                headers_resp["Cache-Control"] = "no-cache, no-store"
 
         return StreamingResponse(process_response(), headers=headers_resp)
 

--- a/src/youwol/pipelines/pipeline_python_backend/pipeline.py
+++ b/src/youwol/pipelines/pipeline_python_backend/pipeline.py
@@ -213,7 +213,7 @@ class DependenciesStep(PipelineStep):
             cmd = (
                 f"(python3 -m venv {VENV_NAME} "
                 f"&& . {VENV_NAME}/bin/activate "
-                f"&& pip install -r ./requirements.txt)"
+                f"&& pip install --force-reinstall -r ./requirements.txt)"
             )
 
             await execute_shell_cmd(cmd=cmd, context=context, cwd=project.path)

--- a/src/youwol/pipelines/pipeline_python_backend/pipeline.py
+++ b/src/youwol/pipelines/pipeline_python_backend/pipeline.py
@@ -242,6 +242,7 @@ async def stop_backend(project: Project, context: Context):
             await env.proxied_backends.terminate(
                 name=project.name, version=project.version, context=ctx
             )
+            await emit_environment_status(context=ctx)
             return {"status": "backend terminated"}
 
         return {"status": "backend or PID not found"}

--- a/src/youwol/pipelines/pipeline_python_backend/template.py
+++ b/src/youwol/pipelines/pipeline_python_backend/template.py
@@ -145,7 +145,7 @@ async def generate_template(folder: Path, parameters: dict[str, str], context: C
             dst=project_folder / ".yw_pipeline",
         )
 
-        return parameters["name"], folder
+        return parameters["name"], project_folder
 
 
 PY_ICON = (

--- a/src/youwol/pipelines/pipeline_python_backend/template/install.sh
+++ b/src/youwol/pipelines/pipeline_python_backend/template/install.sh
@@ -24,5 +24,5 @@ python3 -m venv .venv || exit 1
 
 # Install wheel from ./dist folder
 echo "Installing module from wheel..."
-pip install "./dist/$name-$version-py3-none-any.whl" || exit 1
+pip install --force-reinstall "./dist/$name-$version-py3-none-any.whl" || exit 1
 exit 0

--- a/src/youwol/pipelines/pipeline_raw_app/pipeline.py
+++ b/src/youwol/pipelines/pipeline_raw_app/pipeline.py
@@ -23,22 +23,10 @@ from youwol.utils import Context, parse_json
 
 # Youwol pipelines
 from youwol.pipelines import (
-    CdnTarget,
+    Environment,
     PublishCdnLocalStep,
     create_sub_pipelines_publish_cdn,
 )
-
-
-class Environment(BaseModel):
-    """
-    Specifies the remote CDN targets in which the pipeline publish (using
-    [set_environment](@yw-nav-function:youwol.pipelines.pipeline_raw_app.set_environment)).
-    """
-
-    cdnTargets: list[CdnTarget] = []
-    """
-    The list of (remote) CDN targets.
-    """
 
 
 def set_environment(environment: Environment = Environment()):

--- a/src/youwol/pipelines/pipeline_typescript_weback_npm/environment.py
+++ b/src/youwol/pipelines/pipeline_typescript_weback_npm/environment.py
@@ -1,17 +1,16 @@
 # standard library
 from collections.abc import Callable
 
-# third parties
-from pydantic import BaseModel
-
 # Youwol pipelines
-from youwol.pipelines import CdnTarget
-from youwol.pipelines.pipeline_typescript_weback_npm.common.models import NpmRepo
+from youwol.pipelines import Environment as CdnBaseEnv
+from youwol.pipelines.pipeline_typescript_weback_npm.common.models import (
+    NpmRepo,
+    PublicNpmRepo,
+)
 
 
-class Environment(BaseModel):
-    cdnTargets: list[CdnTarget] = []
-    npmTargets: list[NpmRepo] = []
+class Environment(CdnBaseEnv):
+    npmTargets: list[NpmRepo] = [PublicNpmRepo(name="public")]
 
 
 def set_environment(environment: Environment = Environment()):


### PR DESCRIPTION
*  🐛 [pipeline.py_backend] => fix missing WS status update
*  🐛 [app.routers.python] set `no-cache` for downloaded components.
*  ✨ [pipelines] configured by default to publish in twin remote
*  🐛 [app] missing actual method call in `file_path.exists`
*  🐛 [app] missing update signals from web sockets
*  🐛 [app] fix backends install can be executed twice
*  🐛 [app.projects] fix duplicate issue in projects list response.
*  🐛 [pipeline.py_backend] fix wrong path from `generate_template`
*  🐛 [pipeline.py_backend] fix self-contained venvs.
*  ✅ [integration] => adjust `yw_config` file

TG-2255 #closed
TG-2254 #closed
TG-2261 #closed
TG-2260 #closed
TG-2262 #closed
TG-2263 #closed
TG-2264 #closed
TG-2265 #closed