### PR TITLE
TG-2356: Correct `CHANGELOG.md` management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-0440/).
+
 ## [0.1.10rc1.dev] − Unreleased
 
 ### Fixed
 
 - Resolved intermittent failures in retrieving Pyodide resources. <!-- TG-2351 -->
 
-
 ## [0.1.10rc] − 2024-05-22
-## [0.1.10.dev] − Unreleased
 
 ### Added
 

--- a/version_management.py
+++ b/version_management.py
@@ -14,7 +14,7 @@ from packaging import version
 PYPROJECT_TOML = "pyproject.toml"
 VERSION_FILE = "src/youwol/__init__.py"
 CHANGELOG_MD = "CHANGELOG.md"
-CHANGELOG_HEADER_LINE = 17
+CHANGELOG_HEADER_LINE = 18
 NO_CHANGE_LINE = "_no change_"
 PYTHON_VERSION_PREFIX = "3."
 CLASSIFIER_PYTHON_VERSION = f"Programming Language :: Python :: {PYTHON_VERSION_PREFIX}"


### PR DESCRIPTION
- 🐛 Correct `CHANGELOG.md` content & management

TG-2356 #closed
