### PR TITLE
Feature/misc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 - Upgrade `GET:/co-lab` target from `@youwol/co-lab#^0.3.0` to `@youwol/co-lab#^0.4.0`. <!-- TG-2399 -->
 
 
+<!-- Not worthy of inclusion
+TG-2415 : ⬆️ upgrade `deepdiff` to `7.0.1,<8.0.0`
+-->
+
 ## [0.1.11] − 2024-06-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
   py-youwol environment. <!-- TG-2416 -->
 
 <!-- Not worthy of inclusion
+TG-2414: ♻️ [pipeline TS] Stop using deprecated exported names
 TG-2415 : ⬆️ upgrade `deepdiff` to `7.0.1,<8.0.0`
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 
 - Upgrade `GET:/co-lab` target from `@youwol/co-lab#^0.3.0` to `@youwol/co-lab#^0.4.0`. <!-- TG-2399 -->
 
+### Fixed
+
+- Resolved issues with fetching Pyodide resources when multiple Pyodide runtime versions are available within the
+  py-youwol environment. <!-- TG-2416 -->
 
 <!-- Not worthy of inclusion
 TG-2415 : ⬆️ upgrade `deepdiff` to `7.0.1,<8.0.0`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "colorama>=0.4.5,<0.5.0",
     "colorlog",
     "cowpy>=1.1.5,<2.0.0",
-    "deepdiff>=5.8.1,<6.0.0",
+    "deepdiff>=7.0.1,<8.0.0",
     "fastapi>=0.109.1,<0.110.0",
     "keyring>=24.2.0,<25.0.0",
     "minio>=7.1.9,<8.0.0",

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -310,9 +310,9 @@ cryptography==42.0.4 \
     # via
     #   pyjwt
     #   secretstorage
-deepdiff==5.8.1 \
-    --hash=sha256:8d4eb2c4e6cbc80b811266419cb71dd95a157094a3947ccf937a94d44943c7b8 \
-    --hash=sha256:e9aea49733f34fab9a0897038d8f26f9d94a97db1790f1b814cced89e9e0d2b7
+deepdiff==7.0.1 \
+    --hash=sha256:260c16f052d4badbf60351b4f77e8390bee03a0b516246f6839bc813fb429ddf \
+    --hash=sha256:447760081918216aa4fd4ca78a4b6a848b81307b2ea94c810255334b759e1dc3
     # via youwol (pyproject.toml)
 docutils==0.20.1 \
     --hash=sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6 \

--- a/requirements-no-hashes.txt
+++ b/requirements-no-hashes.txt
@@ -74,7 +74,7 @@ cryptography==42.0.4
     #   types-redis
 cyclonedx-python-lib==4.2.3
     # via pip-audit
-deepdiff==5.8.1
+deepdiff==7.0.1
     # via youwol (pyproject.toml)
 defusedxml==0.7.1
     # via py-serializable

--- a/requirements-publish.txt
+++ b/requirements-publish.txt
@@ -316,9 +316,9 @@ cryptography==42.0.4 \
     # via
     #   pyjwt
     #   secretstorage
-deepdiff==5.8.1 \
-    --hash=sha256:8d4eb2c4e6cbc80b811266419cb71dd95a157094a3947ccf937a94d44943c7b8 \
-    --hash=sha256:e9aea49733f34fab9a0897038d8f26f9d94a97db1790f1b814cced89e9e0d2b7
+deepdiff==7.0.1 \
+    --hash=sha256:260c16f052d4badbf60351b4f77e8390bee03a0b516246f6839bc813fb429ddf \
+    --hash=sha256:447760081918216aa4fd4ca78a4b6a848b81307b2ea94c810255334b759e1dc3
     # via youwol (pyproject.toml)
 docutils==0.20.1 \
     --hash=sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6 \

--- a/requirements-qa.txt
+++ b/requirements-qa.txt
@@ -423,9 +423,9 @@ cyclonedx-python-lib==4.2.3 \
     --hash=sha256:904068b55d1665f0ea96f38307603cc14f95c3b421f1687fc2411326aefde3a6 \
     --hash=sha256:e9b923af525b6acf7bab917a35360b4b562b85dc15fde9eaa500828949adf73a
     # via pip-audit
-deepdiff==5.8.1 \
-    --hash=sha256:8d4eb2c4e6cbc80b811266419cb71dd95a157094a3947ccf937a94d44943c7b8 \
-    --hash=sha256:e9aea49733f34fab9a0897038d8f26f9d94a97db1790f1b814cced89e9e0d2b7
+deepdiff==7.0.1 \
+    --hash=sha256:260c16f052d4badbf60351b4f77e8390bee03a0b516246f6839bc813fb429ddf \
+    --hash=sha256:447760081918216aa4fd4ca78a4b6a848b81307b2ea94c810255334b759e1dc3
     # via youwol (pyproject.toml)
 defusedxml==0.7.1 \
     --hash=sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -426,9 +426,9 @@ cyclonedx-python-lib==4.2.3 \
     --hash=sha256:904068b55d1665f0ea96f38307603cc14f95c3b421f1687fc2411326aefde3a6 \
     --hash=sha256:e9b923af525b6acf7bab917a35360b4b562b85dc15fde9eaa500828949adf73a
     # via pip-audit
-deepdiff==5.8.1 \
-    --hash=sha256:8d4eb2c4e6cbc80b811266419cb71dd95a157094a3947ccf937a94d44943c7b8 \
-    --hash=sha256:e9aea49733f34fab9a0897038d8f26f9d94a97db1790f1b814cced89e9e0d2b7
+deepdiff==7.0.1 \
+    --hash=sha256:260c16f052d4badbf60351b4f77e8390bee03a0b516246f6839bc813fb429ddf \
+    --hash=sha256:447760081918216aa4fd4ca78a4b6a848b81307b2ea94c810255334b759e1dc3
     # via youwol (pyproject.toml)
 defusedxml==0.7.1 \
     --hash=sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69 \

--- a/src/youwol/pipelines/pipeline_typescript_weback_npm/common/utils.py
+++ b/src/youwol/pipelines/pipeline_typescript_weback_npm/common/utils.py
@@ -17,7 +17,6 @@ from youwol.app.routers.projects.models_project import PipelineStep
 
 # Youwol backends
 from youwol.backends.cdn import get_api_key
-from youwol.backends.cdn.loading_graph_implementation import exportedSymbols
 
 # Youwol utilities
 from youwol.utils import JSON, deep_merge, parse_json, write_json
@@ -214,7 +213,7 @@ def get_externals(input_template: Template):
     )
 
     for name, dep_api_version in externals_api_version.items():
-        symbol_name = name if name not in exportedSymbols else exportedSymbols[name]
+        symbol_name = name
         exported_symbols[name] = {
             "apiKey": dep_api_version,
             "exportedSymbol": symbol_name,


### PR DESCRIPTION
*  ⬆️ upgrade deepdiff to `>=7.0.1,<8.0.0`
*  🐛 [app.pyodide] Use pyodide version as module namespace
*  ♻️ [pipeline TS] Stop using deprecated exported names

TG-2415 #closed
TG-2416 #closed
TG-2414