### PR TITLE
TG-2452: merge branch `main` before merge back

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,6 +65,7 @@ jobs:
           name: ${{ steps.get_version_details.outputs.config_dir }}
           path: integrations/
           retention-days: 1
+          include-hidden-files: true
 
 
   tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 
 name: Release
 
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       final_version:
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       python_versions: ${{ steps.job-output.outputs.python_versions }}
-      install_from: ${{ steps.job-output.outputs.install_from }}
       version: ${{ steps.bump_version.outputs.version }}
       commit: ${{ steps.bump_version.outputs.commit }}
       artifact: ${{ steps.bump_version.outputs.artifact }}
+      job_branch: ${{ steps.push_versions_bump.outputs.job_branch }}
 
     steps:
 
@@ -127,19 +127,21 @@ jobs:
           name: config_integration-tests
           path: integrations/
           retention-days: 1
+          include-hidden-files: true
 
-      - name: Push
-        if: "! ${{ inputs.dry-run }}"
-        id: publish_test_pypi
+      - name: Push Versions Bump
+        id: push_versions_bump
         run: |
-          git push
+          job_branch=jobs/release/${GITHUB_RUN_ID}
+          git push -u origin HEAD:${job_branch}
+          echo job_branch=${job_branch} >> $GITHUB_OUTPUT
         shell: sh
 
       - name: Job Output
         id: job-output
         run: |
-         versions_json=$(python version_management.py python_versions)
-         echo python_versions=${versions_json} >> $GITHUB_OUTPUT
+          versions_json=$(python version_management.py python_versions)
+          echo python_versions=${versions_json} >> $GITHUB_OUTPUT
 
 
   tests:
@@ -152,7 +154,7 @@ jobs:
       max-parallel: 1
       matrix:
         python_version: ${{ fromJson(needs.build.outputs.python_versions) }}
-        install_from: ['sources', 'wheel']
+        install_from: [ 'sources', 'wheel' ]
 
     steps:
       - name: Prepare Python ${{ matrix.python_version }}
@@ -225,6 +227,7 @@ jobs:
         id: setup_env
         run: |
           echo "PY_YOUWOL_BIN=$(which youwol)" >> "$GITHUB_ENV"
+          echo "PIP_FIND_LINKS=$(ls -1 $(pwd)/youwol-*.whl)" >> "$GITHUB_ENV"
         shell: sh
 
       - name: Run py-youwol with int conf
@@ -284,14 +287,12 @@ jobs:
         uses: youwol/nestor/ts/prepare@v3
         with:
           repository: youwol/todo-app-ts
-          ref: ${{ inputs.todo-app-ts_ref }}
+          ref: ""
           path: ${{ runner.temp }}/todo-app-ts
 
       - name: Build todo-app-ts
         id: build_todo-app-ts
         uses: youwol/nestor/ts/build@v3
-        with:
-          skip: ${{ inputs.skip }}
 
   doc_app:
     name: Doc App
@@ -310,13 +311,13 @@ jobs:
       - doc_app
 
     steps:
-      - name: Checkout release branch
+      - name: Checkout Job Branch
         id: checkout
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_NESTOR_PYYOUWOL_PUSH }}
-          ref: release/${{ inputs.final_version }}
-          fetch-depth: 2
+          ref: ${{ needs.build.outputs.job_branch }}
+          fetch-depth: 3
 
       - name: Prepare Python 3.12
         id: prepare_python
@@ -353,6 +354,8 @@ jobs:
           TWINE_NON_INTERACTIVE: batch
           VERSION: ${{ needs.build.outputs.version }}
           COMMIT: ${{ needs.build.outputs.commit }}
+          FINAL_VERSION: ${{ inputs.final_version }}
+          JOB_BRANCH: ${{ needs.build.outputs.job_branch }}
         run: |
           tag_msg_1st_line="Published release $VERSION on pypi.org"
           tag_msg_2nd_line="https://pypi.org/project/youwol/$VERSION/"
@@ -363,4 +366,6 @@ jobs:
             -m "${tag_msg_2nd_line}" \
             $COMMIT
           git push --follow-tags
+          git push -u origin HEAD:release/${FINAL_VERSION}
+          git push -u origin :${JOB_BRANCH}
         shell: sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 
 ## [0.1.13.dev] − Unreleased
 
+<!-- Not worthy of inclusion
+TG-1461 : 💚 [release] allow installing local release in venv
+TG-1462 : 💚 [release] push versions bump after publishing
+TG-1464 : 👽️ [workflows] hidden files in uploaded config
+TG-1467 : 💚 [release] Checkout with depth=3 for publishing
+-->
+
 ## [0.1.12] − 2024-09-02
 
 ### Added


### PR DESCRIPTION
- 🔖 prepare for next version 0.1.13
- 💚 [release] allow installing local release in venv
- TG-2461: install local release in CI (#389)
- 💚 [release] push versions bump after publishing
- 🎨 Cleaning `.github/workflows/release.yml`
- TG-2462: push versions bump after publishing (#391)
- 👽️ [workflows] hidden files in uploaded config
- TG-2464: breaking change from `actions/upload-artefact` (#393)
- 💚 [release] Checkout with depth=3 for publishing
- TG-2467: [release] Checkout with depth=3 for publishing (#394)
- Merge branch 'main' into release/0.1.12
