### PR TITLE
TG-2489: double slash when requesting OpenID config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 - **Pipeline Python Backend**:
   -  Pipeline does not produce auto-generated `requirements.txt` anymore. <!-- TG-2459 -->
 
+### Fixed
+
+- **OpenID Connect Discovery**: Remove trailing slash from Issuer when requesting `.well-known` (see [specification](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)) <!-- TG-2489 -->
+
 <!-- Not worthy of inclusion
 TG-2480 : 📝 [doc-app] Add `yw_clients` page
 TG-2474 : 💄 [pipelines] Improve styling of config. step views

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,14 @@ and this project adheres to [PEP 440 Versioning](https://peps.python.org/pep-044
 
 ### Added
 
--  **yw_clients**:
+- **yw_clients**:
   - Add new python package `yw_clients` in `/lib`. It provides HTTP clients and logs management to interact
     with YouWol's backends. <!-- TG-2480 -->
 
 ### Changed
 
 - **Pipeline Python Backend**:
-  -  Pipeline does not produce auto-generated `requirements.txt` anymore. <!-- TG-2459 -->
+  - Pipeline does not produce auto-generated `requirements.txt` anymore. <!-- TG-2459 -->
 
 ### Fixed
 

--- a/src/youwol/utils/clients/oidc/oidc_config.py
+++ b/src/youwol/utils/clients/oidc/oidc_config.py
@@ -310,7 +310,9 @@ class OidcConfig:
 
         """
         if self._openid_configuration is None:
-            well_known_url = f"{self.base_url}/.well-known/openid-configuration"
+            well_known_url = (
+                f"{self.base_url.rstrip('/')}/.well-known/openid-configuration"
+            )
             async with aiohttp.ClientSession() as session:
                 async with session.get(well_known_url) as resp:
                     if resp.status != 200:


### PR DESCRIPTION
- 🐛 [openid] remove trailing slash for discovery
- 🎨 Format `CHANGELOG.md`

TG-2489 #closed
