### PR TITLE
TG-2532 & TG-2533 : Allow ignore files in publication & pyproject.toml finds submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ TG-2500 : 🥅 [custom-backends] Fallback to local-install if docker not availab
 TG-2501 : 📝 [custom-backends] Code documentation
 TG-2509 : 🐛 [pipeline-py-backend] `DependenciesStep` handle errors & outputs
 TG-2532 : ✨ [pipeline-TS] Allow `ignore` files in publication
+TG-2533 : 🔧 [pipeline-py-backend] `pyproject.toml` finds submodules 
 -->
 
 ## [0.1.12] − 2024-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ TG-2499 : 🐛 [app.custom-backend] Fix host IP address provisioning in containe
 TG-2500 : 🥅 [custom-backends] Fallback to local-install if docker not available.
 TG-2501 : 📝 [custom-backends] Code documentation
 TG-2509 : 🐛 [pipeline-py-backend] `DependenciesStep` handle errors & outputs
+TG-2532 : ✨ [pipeline-TS] Allow `ignore` files in publication
 -->
 
 ## [0.1.12] − 2024-09-02

--- a/src/youwol/pipelines/pipeline_python_backend/template/pyproject.toml.txt
+++ b/src/youwol/pipelines/pipeline_python_backend/template/pyproject.toml.txt
@@ -36,8 +36,10 @@ requires = [
     "setuptools>=67.7.2",
 ]
 
-[tool.setuptools]
-packages = ["{{package_name}}"]
+[tool.setuptools.packages.find]
+where = ["./"]
+include = ["{{package_name}}","{{package_name}}.*"]
+exclude = []
 
 [tool.isort]
 profile = "black"

--- a/src/youwol/pipelines/pipeline_typescript_weback_npm/regular/pipeline.py
+++ b/src/youwol/pipelines/pipeline_typescript_weback_npm/regular/pipeline.py
@@ -34,6 +34,7 @@ from .test_step import TestStep, TestStepConfig
 class PublishConfig(BaseModel):
     packagedArtifacts: list[str] = ["dist", "docs", "test-coverage"]
     packagedFolders: list[str] = []
+    ignore: list[str] = []
 
 
 class PipelineConfig(BaseModel):
@@ -67,6 +68,7 @@ async def pipeline(config: PipelineConfig, context: Context):
             PublishCdnLocalStep(
                 packagedArtifacts=config.publishConfig.packagedArtifacts,
                 packagedFolders=config.publishConfig.packagedFolders,
+                ignore=config.publishConfig.ignore,
             ),
             *publish_remote_steps,
         ]


### PR DESCRIPTION
*  ✨ [pipeline-TS] Allow `ignore` files in publication
*  🔧 [pipeline-py-backend] `pyproject.toml` finds submodules

TG-2532 #closed
TG-2533 #closed