### PR TITLE
TG-2525 Pipeline backend: failed install should be displayed in std out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ TG-2501 : 📝 [custom-backends] Code documentation
 TG-2509 : 🐛 [pipeline-py-backend] `DependenciesStep` handle errors & outputs
 TG-2532 : ✨ [pipeline-TS] Allow `ignore` files in publication
 TG-2533 : 🔧 [pipeline-py-backend] `pyproject.toml` finds submodules 
+TG-2525 : 🔊 [utils] `CommandException` reports its outputs
 -->
 
 ## [0.1.12] − 2024-09-02

--- a/integrations/yw_config.py
+++ b/integrations/yw_config.py
@@ -467,6 +467,10 @@ class ConfigurationFactory(IConfigurationFactory):
                             do_post=apply_test_labels_logs,
                         ),
                         Command(
+                            name="print-server-std-out",
+                            do_post=lambda body, _ctx: print(body['text']),
+                        ),
+                        Command(
                             name="encode-extra-index",
                             do_post=encode_extra_index,
                         ),

--- a/src/youwol/utils/utils_shell.py
+++ b/src/youwol/utils/utils_shell.py
@@ -20,7 +20,7 @@ class CommandException(Exception):
     def __init__(self, command: str, outputs: list[str]):
         self.command = command
         self.outputs = outputs
-        super().__init__(f"{self.command} failed")
+        super().__init__(f"{self.command} failed.\n\nOutputs:{''.join(outputs)}")
 
 
 def clone_environ(env_variables: dict[str, str]) -> dict[str, str]:


### PR DESCRIPTION
*  🔊 [utils] `CommandException` reports its outputs
*  ✅ [IT] Add command `print-server-std-out`

TG-2525